### PR TITLE
Adding severity to incomplete HID when POST an action Snapshot

### DIFF
--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -102,7 +102,6 @@ class ActionView(View):
         # Check if HID is null and add Severity:Warning to Snapshot
         if snapshot.device.hid is None:
             snapshot.severity = Severity.Warning
-            snapshot.device.hid = ''
         db.session.add(snapshot)
         db.session().final_flush()
         ret = self.schema.jsonify(snapshot)  # transform it back

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -12,7 +12,7 @@ from ereuse_devicehub.resources.action.models import Action, RateComputer, Snaps
     InitTransfer
 from ereuse_devicehub.resources.action.rate.v1_0 import CannotRate
 from ereuse_devicehub.resources.device.models import Component, Computer
-from ereuse_devicehub.resources.enums import SnapshotSoftware
+from ereuse_devicehub.resources.enums import SnapshotSoftware, Severity
 
 SUPPORTED_WORKBENCH = StrictVersion('11.0')
 
@@ -98,8 +98,11 @@ class ActionView(View):
                 if price:
                     snapshot.actions.add(price)
         elif snapshot.software == SnapshotSoftware.WorkbenchAndroid:
-            pass    # TODO try except to compute RateMobile
-
+            pass  # TODO try except to compute RateMobile
+        # Check if HID is null and add Severity:Warning to Snapshot
+        if snapshot.device.hid is None:
+            snapshot.severity = Severity.Warning
+            snapshot.device.hid = ''
         db.session.add(snapshot)
         db.session().final_flush()
         ret = self.schema.jsonify(snapshot)  # transform it back

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -52,7 +52,7 @@ class Device(Thing):
     """
     type = Column(Unicode(STR_SM_SIZE), nullable=False)
     hid = Column(Unicode(), check_lower('hid'), unique=False)
-    hid.comment = """The Hardware ID (HID) is the unique ID traceability
+    hid.comment = """The Hardware ID (HID) is the ID traceability
     systems use to ID a device globally. This field is auto-generated
     from Devicehub using literal identifiers from the device,
     so it can re-generated *offline*.

--- a/ereuse_devicehub/resources/device/sync.py
+++ b/ereuse_devicehub/resources/device/sync.py
@@ -12,7 +12,6 @@ from teal.marshmallow import ValidationError
 
 from ereuse_devicehub.db import db
 from ereuse_devicehub.resources.action.models import Remove
-from ereuse_devicehub.resources.device.exceptions import NeedsId
 from ereuse_devicehub.resources.device.models import Component, Computer, Device
 from ereuse_devicehub.resources.tag.model import Tag
 
@@ -151,11 +150,8 @@ class Sync:
         """
         assert inspect(device).transient, 'Device cannot be already synced from DB'
         assert all(inspect(tag).transient for tag in device.tags), 'Tags cannot be synced from DB'
-        if not device.tags and not device.hid:
-            # We cannot identify this device
-            raise NeedsId()
         db_device = None
-        if device.hid:
+        if device.hid is not None:
             with suppress(ResourceNotFound):
                 db_device = Device.query.filter_by(hid=device.hid).one()
         try:

--- a/ereuse_devicehub/resources/device/sync.py
+++ b/ereuse_devicehub/resources/device/sync.py
@@ -151,7 +151,7 @@ class Sync:
         assert inspect(device).transient, 'Device cannot be already synced from DB'
         assert all(inspect(tag).transient for tag in device.tags), 'Tags cannot be synced from DB'
         db_device = None
-        if device.hid is not None:
+        if device.hid:
             with suppress(ResourceNotFound):
                 db_device = Device.query.filter_by(hid=device.hid).one()
         try:

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -247,6 +247,7 @@ def test_snapshot_post_without_hid(user: UserClient):
     assert snapshot['author']['id'] == user.user['id']
     assert 'actions' not in snapshot['device']
     assert 'author' not in snapshot['device']
+    assert snapshot['severity'] == 'Warning'
     response = user.post(snapshot, res=Snapshot)
     assert response.status == 201
 


### PR DESCRIPTION
When POST an **action snapshot**, if one of the **HID** fields inside Snapshot are empty/null _(type - manufacturer - model - serialNumber)_. We adding a **Severity** on action snapshot to mark like incomplete snapshot.

Check _ereuse_devicehub/resources/device/sync.py_ where are **NeedsId Exception**

In case the device cannot be identified using the HID and we don't have an associated tag either. As we solve the conflict of duplication of equal devices. To know if a snapshot belongs to a previously uploaded device or is it a new one?

@fedjo There is some relation between the use of Tags and the fact of allowing to upload a snapshot with an incomplete HID (and therefore not unique..)

I'm not sure if it's a good idea to upload these changes but at least to raise this issue.

Relates #35 