### PR TITLE
Feature/61 json backup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,6 @@ ENV/
 
 # Environment
 .env
+
+# Temporal dir
+tmp/

--- a/ereuse_devicehub/config.py
+++ b/ereuse_devicehub/config.py
@@ -44,6 +44,9 @@ class DevicehubConfig(Config):
     """The minimum version of ereuse.org workbench that this devicehub
     accepts. we recommend not changing this value.
     """
+
+    TMP_SNAPSHOTS = config('TMP_SNAPSHOTS', '/tmp/snapshots')
+    """This var is for save a snapshots in json format when fail something"""
     API_DOC_CONFIG_TITLE = 'Devicehub'
     API_DOC_CONFIG_VERSION = '0.2'
     API_DOC_CONFIG_COMPONENTS = {

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -2,12 +2,10 @@ import os
 import json
 from time import time
 from distutils.version import StrictVersion
-from typing import List
 from uuid import UUID
 
 from flask import current_app as app, request, g
 from sqlalchemy.util import OrderedSet
-from marshmallow.exceptions import ValidationError as mValidationError
 from teal.marshmallow import ValidationError
 from teal.resource import View
 
@@ -15,7 +13,6 @@ from ereuse_devicehub.db import db
 from ereuse_devicehub.resources.action.models import Action, RateComputer, Snapshot, VisualTest, \
     InitTransfer
 from ereuse_devicehub.resources.action.rate.v1_0 import CannotRate
-from ereuse_devicehub.resources.device.models import Component, Computer
 from ereuse_devicehub.resources.enums import SnapshotSoftware, Severity
 from ereuse_devicehub.resources.user.exceptions import InsufficientPermission
 

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -1,6 +1,5 @@
 import os
 import json
-import copy
 from time import time
 from distutils.version import StrictVersion
 from typing import List
@@ -8,6 +7,7 @@ from uuid import UUID
 
 from flask import current_app as app, request, g
 from sqlalchemy.util import OrderedSet
+from marshmallow.exceptions import ValidationError as mValidationError
 from teal.marshmallow import ValidationError
 from teal.resource import View
 
@@ -24,26 +24,28 @@ SUPPORTED_WORKBENCH = StrictVersion('11.0')
 TMP_SNAPSHOTS = 'tmp/snapshots'
 
 
-def save_snapshot_in_file(snapshot_json):
+def save_json(req_json):
     """
     This function allow save a snapshot in json format un a TMP_SNAPSHOTS directory
     The file need to be saved with one name format with the stamptime and uuid joins
     """
-    name_file = "{uuid}_{time}.json".format(uuid=snapshot_json['uuid'], time=int(time()))
+    name_file = "{uuid}_{time}.json".format(uuid=req_json.get('uuid', ''), time=int(time()))
     path_name = "{tmp}/{file}".format(tmp=TMP_SNAPSHOTS, file=name_file)
 
     if not os.path.isdir(TMP_SNAPSHOTS):
         os.system('mkdir -p {}'.format(TMP_SNAPSHOTS))
 
     snapshot_file = open(path_name, 'w')
-    snapshot_file.write(json.dumps(snapshot_json))
+    snapshot_file.write(json.dumps(req_json))
     snapshot_file.close()
+    return path_name
 
 
 class ActionView(View):
     def post(self):
         """Posts an action."""
         json = request.get_json(validate=False)
+        path_snapshot = save_json(json)
         if not json or 'type' not in json:
             raise ValidationError('Resource needs a type.')
         # todo there should be a way to better get subclassess resource
@@ -51,11 +53,14 @@ class ActionView(View):
         resource_def = app.resources[json['type']]
         a = resource_def.schema.load(json)
         if json['type'] == Snapshot.t:
-            return self.snapshot(a, resource_def)
+            response = self.snapshot(a, resource_def)
+            os.remove(path_snapshot)
+            return response
         if json['type'] == VisualTest.t:
             pass
             # TODO JN add compute rate with new visual test and old components device
         if json['type'] == InitTransfer.t:
+            os.remove(path_snapshot)
             return self.transfer_ownership()
         Model = db.Model._decl_class_registry.data[json['type']]()
         action = Model(**a)
@@ -64,6 +69,7 @@ class ActionView(View):
         ret = self.schema.jsonify(action)
         ret.status_code = 201
         db.session.commit()
+        os.remove(path_snapshot)
         return ret
 
     def one(self, id: UUID):
@@ -80,67 +86,62 @@ class ActionView(View):
         # model object, when we flush them to the db we will flush
         # snapshot, and we want to wait to flush snapshot at the end
 
-        snapshot_json_bakup = copy.copy(snapshot_json)
-        try:
-            device = snapshot_json.pop('device')  # type: Computer
-            components = None
-            if snapshot_json['software'] == (SnapshotSoftware.Workbench or SnapshotSoftware.WorkbenchAndroid):
-                components = snapshot_json.pop('components', None)  # type: List[Component]
-            snapshot = Snapshot(**snapshot_json)
+        device = snapshot_json.pop('device')  # type: Computer
+        components = None
+        if snapshot_json['software'] == (SnapshotSoftware.Workbench or SnapshotSoftware.WorkbenchAndroid):
+            components = snapshot_json.pop('components', None)  # type: List[Component]
+        snapshot = Snapshot(**snapshot_json)
 
-            # Remove new actions from devices so they don't interfere with sync
-            actions_device = set(e for e in device.actions_one)
-            device.actions_one.clear()
-            if components:
-                actions_components = tuple(set(e for e in c.actions_one) for c in components)
-                for component in components:
-                    component.actions_one.clear()
+        # Remove new actions from devices so they don't interfere with sync
+        actions_device = set(e for e in device.actions_one)
+        device.actions_one.clear()
+        if components:
+            actions_components = tuple(set(e for e in c.actions_one) for c in components)
+            for component in components:
+                component.actions_one.clear()
 
-            assert not device.actions_one
-            assert all(not c.actions_one for c in components) if components else True
-            db_device, remove_actions = resource_def.sync.run(device, components)
+        assert not device.actions_one
+        assert all(not c.actions_one for c in components) if components else True
+        db_device, remove_actions = resource_def.sync.run(device, components)
 
-            del device  # Do not use device anymore
-            snapshot.device = db_device
-            snapshot.actions |= remove_actions | actions_device  # Set actions to snapshot
-            # commit will change the order of the components by what
-            # the DB wants. Let's get a copy of the list so we preserve order
-            ordered_components = OrderedSet(x for x in snapshot.components)
+        del device  # Do not use device anymore
+        snapshot.device = db_device
+        snapshot.actions |= remove_actions | actions_device  # Set actions to snapshot
+        # commit will change the order of the components by what
+        # the DB wants. Let's get a copy of the list so we preserve order
+        ordered_components = OrderedSet(x for x in snapshot.components)
 
-            # Add the new actions to the db-existing devices and components
-            db_device.actions_one |= actions_device
-            if components:
-                for component, actions in zip(ordered_components, actions_components):
-                    component.actions_one |= actions
-                    snapshot.actions |= actions
+        # Add the new actions to the db-existing devices and components
+        db_device.actions_one |= actions_device
+        if components:
+            for component, actions in zip(ordered_components, actions_components):
+                component.actions_one |= actions
+                snapshot.actions |= actions
 
-            if snapshot.software == SnapshotSoftware.Workbench:
-                # Check ownership of (non-component) device to from current.user
-                if db_device.owner_id != g.user.id:
-                    raise InsufficientPermission()
-                # Compute ratings
-                try:
-                    rate_computer, price = RateComputer.compute(db_device)
-                except CannotRate:
-                    pass
-                else:
-                    snapshot.actions.add(rate_computer)
-                    if price:
-                        snapshot.actions.add(price)
-            elif snapshot.software == SnapshotSoftware.WorkbenchAndroid:
-                pass  # TODO try except to compute RateMobile
-            # Check if HID is null and add Severity:Warning to Snapshot
-            if snapshot.device.hid is None:
-                snapshot.severity = Severity.Warning
-            db.session.add(snapshot)
-            db.session().final_flush()
-            ret = self.schema.jsonify(snapshot)  # transform it back
-            ret.status_code = 201
-            db.session.commit()
-            return ret
-        except Exception as err:
-            save_snapshot_in_file(snapshot_json_bakup)
-            raise err
+        if snapshot.software == SnapshotSoftware.Workbench:
+            # Check ownership of (non-component) device to from current.user
+            if db_device.owner_id != g.user.id:
+                raise InsufficientPermission()
+            # Compute ratings
+            try:
+                rate_computer, price = RateComputer.compute(db_device)
+            except CannotRate:
+                pass
+            else:
+                snapshot.actions.add(rate_computer)
+                if price:
+                    snapshot.actions.add(price)
+        elif snapshot.software == SnapshotSoftware.WorkbenchAndroid:
+            pass  # TODO try except to compute RateMobile
+        # Check if HID is null and add Severity:Warning to Snapshot
+        if snapshot.device.hid is None:
+            snapshot.severity = Severity.Warning
+        db.session.add(snapshot)
+        db.session().final_flush()
+        ret = self.schema.jsonify(snapshot)  # transform it back
+        ret.status_code = 201
+        db.session.commit()
+        return ret
 
     def transfer_ownership(self):
         """Perform a InitTransfer action to change author_id of device"""

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -35,9 +35,9 @@ def save_json(req_json):
     if not os.path.isdir(TMP_SNAPSHOTS):
         os.system('mkdir -p {}'.format(TMP_SNAPSHOTS))
 
-    snapshot_file = open(path_name, 'w')
-    snapshot_file.write(json.dumps(req_json))
-    snapshot_file.close()
+    with open(path_name, 'w') as snapshot_file:
+        snapshot_file.write(json.dumps(req_json))
+
     return path_name
 
 

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -2,7 +2,7 @@
 
 import os
 import json
-from time import time
+from datetime import datetime
 from distutils.version import StrictVersion
 from uuid import UUID
 
@@ -21,12 +21,18 @@ from ereuse_devicehub.resources.user.exceptions import InsufficientPermission
 SUPPORTED_WORKBENCH = StrictVersion('11.0')
 
 
-def save_json(req_json, tmp_snapshots):
+def save_json(req_json, tmp_snapshots, user):
     """
     This function allow save a snapshot in json format un a TMP_SNAPSHOTS directory
     The file need to be saved with one name format with the stamptime and uuid joins
     """
-    name_file = "{uuid}_{time}.json".format(uuid=req_json.get('uuid', ''), time=int(time()))
+    uuid = req_json.get('uuid', '')
+    now = datetime.now()
+    year = now.year
+    month = now.month
+    day = now.day
+
+    name_file = f"{uuid}_{user}_{year}-{month}-{day}.json"
     path_name = os.path.join(tmp_snapshots, name_file)
 
     if not os.path.isdir(tmp_snapshots):
@@ -43,7 +49,7 @@ class ActionView(View):
         """Posts an action."""
         json = request.get_json(validate=False)
         tmp_snapshots = app.config['TMP_SNAPSHOTS']
-        path_snapshot = save_json(json, tmp_snapshots)
+        path_snapshot = save_json(json, tmp_snapshots, g.user.email)
         if not json or 'type' not in json:
             raise ValidationError('Resource needs a type.')
         # todo there should be a way to better get subclassess resource

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -1,3 +1,5 @@
+""" This is the view for Snapshots """
+
 import os
 import json
 from time import time
@@ -18,19 +20,17 @@ from ereuse_devicehub.resources.user.exceptions import InsufficientPermission
 
 SUPPORTED_WORKBENCH = StrictVersion('11.0')
 
-TMP_SNAPSHOTS = 'tmp/snapshots'
 
-
-def save_json(req_json):
+def save_json(req_json, tmp_snapshots):
     """
     This function allow save a snapshot in json format un a TMP_SNAPSHOTS directory
     The file need to be saved with one name format with the stamptime and uuid joins
     """
     name_file = "{uuid}_{time}.json".format(uuid=req_json.get('uuid', ''), time=int(time()))
-    path_name = os.path.join(TMP_SNAPSHOTS, name_file)
+    path_name = os.path.join(tmp_snapshots, name_file)
 
-    if not os.path.isdir(TMP_SNAPSHOTS):
-        os.system('mkdir -p {}'.format(TMP_SNAPSHOTS))
+    if not os.path.isdir(tmp_snapshots):
+        os.system('mkdir -p {}'.format(tmp_snapshots))
 
     with open(path_name, 'w') as snapshot_file:
         snapshot_file.write(json.dumps(req_json))
@@ -42,7 +42,8 @@ class ActionView(View):
     def post(self):
         """Posts an action."""
         json = request.get_json(validate=False)
-        path_snapshot = save_json(json)
+        tmp_snapshots = app.config['TMP_SNAPSHOTS']
+        path_snapshot = save_json(json, tmp_snapshots)
         if not json or 'type' not in json:
             raise ValidationError('Resource needs a type.')
         # todo there should be a way to better get subclassess resource

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -22,7 +22,7 @@ SUPPORTED_WORKBENCH = StrictVersion('11.0')
 TMP_SNAPSHOTS = 'tmp/snapshots'
 
 
-def save_snapshot_on_file(snapshot_json):
+def save_snapshot_in_file(snapshot_json):
     """
     This function allow save a snapshot in json format un a TMP_SNAPSHOTS directory
     The file need to be saved with one name format with the stamptime and uuid joins

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -30,7 +30,7 @@ def save_json(req_json):
     The file need to be saved with one name format with the stamptime and uuid joins
     """
     name_file = "{uuid}_{time}.json".format(uuid=req_json.get('uuid', ''), time=int(time()))
-    path_name = "{tmp}/{file}".format(tmp=TMP_SNAPSHOTS, file=name_file)
+    path_name = os.path.join(tmp=TMP_SNAPSHOTS, file=name_file)
 
     if not os.path.isdir(TMP_SNAPSHOTS):
         os.system('mkdir -p {}'.format(TMP_SNAPSHOTS))

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -30,7 +30,7 @@ def save_json(req_json):
     The file need to be saved with one name format with the stamptime and uuid joins
     """
     name_file = "{uuid}_{time}.json".format(uuid=req_json.get('uuid', ''), time=int(time()))
-    path_name = os.path.join(tmp=TMP_SNAPSHOTS, file=name_file)
+    path_name = os.path.join(TMP_SNAPSHOTS, name_file)
 
     if not os.path.isdir(TMP_SNAPSHOTS):
         os.system('mkdir -p {}'.format(TMP_SNAPSHOTS))

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -1,4 +1,5 @@
 import os
+import json
 from time import time
 from distutils.version import StrictVersion
 from typing import List

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -31,8 +31,10 @@ def save_json(req_json, tmp_snapshots, user):
     year = now.year
     month = now.month
     day = now.day
+    hour = now.hour
+    minutes = now.min
 
-    name_file = f"{uuid}_{user}_{year}-{month}-{day}.json"
+    name_file = f"{year}-{month}-{day}-{hour}-{minutes}_{user}_{uuid}.json"
     path_name = os.path.join(tmp_snapshots, name_file)
 
     if not os.path.isdir(tmp_snapshots):

--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -1,3 +1,5 @@
+import os
+from time import time
 from distutils.version import StrictVersion
 from typing import List
 from uuid import UUID
@@ -16,6 +18,23 @@ from ereuse_devicehub.resources.enums import SnapshotSoftware, Severity
 from ereuse_devicehub.resources.user.exceptions import InsufficientPermission
 
 SUPPORTED_WORKBENCH = StrictVersion('11.0')
+
+TMP_SNAPSHOTS = 'tmp/snapshots'
+
+
+def save_snapshot_on_file(snapshot_json):
+    """
+    This function allow save a snapshot in json format un a TMP_SNAPSHOTS directory
+    The file need to be saved with one name format with the stamptime and uuid joins
+    """
+    if not os.path.isdir(TMP_SNAPSHOTS):
+        os.system('mkdir -p {}'.format(TMP_SNAPSHOTS))
+
+    name_file = "{uuid}_{time}.json".format(uuid=snapshot_json['uuid'], time=int(time()))
+    path_name = "{tmp}/{file}".format(tmp=TMP_SNAPSHOTS, file=name_file)
+    snapshot_file = open(path_name, 'w')
+    snapshot_file.write(json.dumps(snapshot_json))
+    snapshot_file.close()
 
 
 class ActionView(View):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,7 @@ class TestConfig(DevicehubConfig):
     SQLALCHEMY_DATABASE_URI = 'postgresql://dhub:ereuse@localhost/dh_test'
     TESTING = True
     SERVER_NAME = 'localhost'
+    TMP_SNAPSHOTS = '/tmp/snapshots'
 
 
 @pytest.fixture(scope='session')

--- a/tests/files/basic.snapshot.badly_formed.yaml
+++ b/tests/files/basic.snapshot.badly_formed.yaml
@@ -1,0 +1,30 @@
+type: Snapshot
+uuid: 9a3e7485-fdd0-47ce-bcc7-65c55226b598
+version: '11.0b9'
+software: Workbench
+elapsed: 4
+device:
+  type: Desktop
+  chassis: Microtower
+  serialNumber: null
+  model: null
+  manufacturer: null
+  actions:
+    - type: VisualTest
+      appearanceRange: A
+      functionalityRange: B
+components:
+  - type: RamModule
+    serialNumber: rm1s
+    model: rm1ml
+    manufacturer: rm1mr
+    speed: 1333
+  - type: Processor
+    serialNumber: p1s
+    model: p1ml
+    manufacturer: p1mr
+    speed: 1.6
+    actions:
+      - type: BenchmarkProcessorr
+        rate: 2410
+        elapsed: 11

--- a/tests/files/failed.snapshot.422.missing-chassis.yaml
+++ b/tests/files/failed.snapshot.422.missing-chassis.yaml
@@ -1,0 +1,36 @@
+type: Snapshot
+uuid: 62b3e393-0c25-42cf-a5fa-ab796fac76dd
+version: 11.0
+software: Workbench
+elapsed: 4
+device: 
+  type: Laptop
+  chassis: Notebook
+  serialNumber: d6s
+  model: d6ml
+  manufacturer: d6mr
+components: 
+  - type: RamModule
+    serialNumber: rm6s
+    model: rm6ml
+    manufacturer: rm6mr
+    speed: 1333
+  - type: Processor
+    serialNumber: p6s
+    model: p6ml
+    manufacturer: p6mr
+    speed: 1.6
+    actions: 
+      - type: BenchmarkProcessor
+        rate: 2410
+        elapsed: 11
+  - type: HardDrive
+    size: 160041.88569599998
+    model: hdd4m
+    manufacturer: hdd4mr
+    serialNumber: hdd4s
+    actions: 
+      - type: BenchmarkDataStorage
+        elapsed: 22
+        writeSpeed: 17.3
+        readSpeed: 41.6

--- a/tests/files/failed.snapshot.422.null-chassis.yaml
+++ b/tests/files/failed.snapshot.422.null-chassis.yaml
@@ -1,0 +1,36 @@
+type: Snapshot
+uuid: 81e1f340-5aac-4619-931b-d312e4866cb7
+version: 11.0
+software: Workbench
+elapsed: 4
+device: 
+  type: Laptop
+  chassis: null
+  serialNumber: d5s
+  model: d5ml
+  manufacturer: d5mr
+components: 
+  - type: RamModule
+    serialNumber: rm5s
+    model: rm5ml
+    manufacturer: rm5mr
+    speed: 1333
+    type: Processor
+    serialNumber: p5s
+    model: p5ml
+    manufacturer: p5mr
+    speed: 1.6
+    actions: 
+      - type: BenchmarkProcessor
+        rate: 2410
+        elapsed: 11
+    size: 160041.88569599998
+    model: hdd5m
+    type: HardDrive
+    manufacturer: hdd5mr
+    serialNumber: hdd5s
+    actions: 
+      - type: BenchmarkDataStorage
+        elapsed: 22
+        writeSpeed: 17.3
+        readSpeed: 41.6

--- a/tests/files/failed.snapshot.500.missing-cpu-benchmark.yaml
+++ b/tests/files/failed.snapshot.500.missing-cpu-benchmark.yaml
@@ -1,0 +1,22 @@
+type: Snapshot
+uuid: 127fad1c-a3f2-4677-9dab-4a370071a882
+version: 11.0
+software: Workbench
+elapsed: 4
+device: 
+  type: Laptop
+  chassis: Microtower
+  serialNumber: d2s
+  model: d2ml
+  manufacturer: d2mr
+components: 
+  - type: RamModule
+    serialNumber: rm2s
+    model: rm2ml
+    manufacturer: rm2mr
+    speed: 1333
+  - type: Processor
+    serialNumber: p2s
+    model: p2ml
+    manufacturer: p2mr
+    speed: 1.6

--- a/tests/files/failed.snapshot.500.missing-hdd-benchmark.yaml
+++ b/tests/files/failed.snapshot.500.missing-hdd-benchmark.yaml
@@ -1,0 +1,31 @@
+type: Snapshot
+uuid: 2afa5413-9858-4577-8273-a027a647fed0
+version: 11.0
+software: Workbench
+elapsed: 4
+device: 
+  type: Desktop
+  chassis: Microtower
+  serialNumber: d3s
+  model: d3ml
+  manufacturer: d3mr
+components: 
+  - type: RamModule
+    serialNumber: rm3s
+    model: rm3ml
+    manufacturer: rm3mr
+    speed: 1333
+  - type: Processor
+    serialNumber: p3s
+    model: p3ml
+    manufacturer: p3mr
+    speed: 1.6
+    size: 160041.88569599998
+    model: hdd3m
+    type: HardDrive
+    manufacturer: hdd3mr
+    serialNumber: hdd3s
+    actions: 
+      - type: BenchmarkProcessor
+        rate: 2410
+        elapsed: 11

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -26,7 +26,7 @@ from ereuse_devicehub.resources.device.sync import MismatchBetweenProperties, \
 from ereuse_devicehub.resources.enums import ComputerChassis, SnapshotSoftware
 from ereuse_devicehub.resources.tag import Tag
 from ereuse_devicehub.resources.user.models import User
-from ereuse_devicehub.resources.action.views import TMP_SNAPSHOTS, save_json
+from ereuse_devicehub.resources.action.views import save_json
 from tests.conftest import file
 
 
@@ -481,17 +481,18 @@ def test_pc_2(user: UserClient):
 
 
 @pytest.mark.mvp
-def test_save_snapshot_in_file():
+def test_save_snapshot_in_file(app: Devicehub):
     """ This test check if works the function save_snapshot_in_file """
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
     snapshot_no_hid = file('basic.snapshot.nohid')
-    save_json(snapshot_no_hid)
+    save_json(snapshot_no_hid, tmp_snapshots)
 
     uuid = snapshot_no_hid['uuid']
-    files = [x for x in os.listdir(TMP_SNAPSHOTS) if uuid in x]
+    files = [x for x in os.listdir(tmp_snapshots) if uuid in x]
 
     snapshot = {'software': '', 'version': '', 'uuid': ''}
     if files:
-        path_snapshot = os.path.join(TMP_SNAPSHOTS, files[0])
+        path_snapshot = os.path.join(tmp_snapshots, files[0])
         with open(path_snapshot) as file_snapshot:
             snapshot = json.loads(file_snapshot.read())
 
@@ -503,8 +504,9 @@ def test_save_snapshot_in_file():
 
 
 @pytest.mark.mvp
-def test_backup_snapshot_with_errors(user: UserClient):
+def test_backup_snapshot_with_errors(app: Devicehub, user: UserClient):
     """ This test check if the file snapshot is create when some snapshot is wrong """
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
     snapshot_no_hid = file('basic.snapshot.badly_formed')
     uuid = snapshot_no_hid['uuid']
 
@@ -512,9 +514,9 @@ def test_backup_snapshot_with_errors(user: UserClient):
     with pytest.raises(KeyError):
         response = user.post(res=Snapshot, data=snapshot_no_hid)
 
-    files = [x for x in os.listdir(TMP_SNAPSHOTS) if uuid in x]
+    files = [x for x in os.listdir(tmp_snapshots) if uuid in x]
     if files:
-        path_snapshot = os.path.join(TMP_SNAPSHOTS, files[0])
+        path_snapshot = os.path.join(tmp_snapshots, files[0])
         with open(path_snapshot) as file_snapshot:
             snapshot = json.loads(file_snapshot.read())
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -525,3 +525,101 @@ def test_backup_snapshot_with_errors(app: Devicehub, user: UserClient):
     assert snapshot['software'] == snapshot_no_hid['software']
     assert snapshot['version'] == snapshot_no_hid['version']
     assert snapshot['uuid'] == uuid
+
+
+@pytest.mark.mvp
+def test_snapshot_failed_missing_cpu_benchmark(app: Devicehub, user: UserClient):
+    """ This test check if the file snapshot is create when some snapshot is wrong """
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
+    snapshot_error = file('failed.snapshot.500.missing-cpu-benchmark')
+    uuid = snapshot_error['uuid']
+
+    snapshot = {'software': '', 'version': '', 'uuid': ''}
+    with pytest.raises(TypeError):
+        user.post(res=Snapshot, data=snapshot_error)
+
+    files = [x for x in os.listdir(tmp_snapshots) if uuid in x]
+    if files:
+        path_snapshot = os.path.join(tmp_snapshots, files[0])
+        with open(path_snapshot) as file_snapshot:
+            snapshot = json.loads(file_snapshot.read())
+
+        os.remove(path_snapshot)
+
+    assert snapshot['software'] == snapshot_error['software']
+    assert snapshot['version'] == snapshot_error['version']
+    assert snapshot['uuid'] == uuid
+
+
+@pytest.mark.mvp
+def test_snapshot_failed_missing_hdd_benchmark(app: Devicehub, user: UserClient):
+    """ This test check if the file snapshot is create when some snapshot is wrong """
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
+    snapshot_error = file('failed.snapshot.500.missing-hdd-benchmark')
+    uuid = snapshot_error['uuid']
+
+    snapshot = {'software': '', 'version': '', 'uuid': ''}
+    with pytest.raises(TypeError):
+        user.post(res=Snapshot, data=snapshot_error)
+
+    files = [x for x in os.listdir(tmp_snapshots) if uuid in x]
+    if files:
+        path_snapshot = os.path.join(tmp_snapshots, files[0])
+        with open(path_snapshot) as file_snapshot:
+            snapshot = json.loads(file_snapshot.read())
+
+        os.remove(path_snapshot)
+
+    assert snapshot['software'] == snapshot_error['software']
+    assert snapshot['version'] == snapshot_error['version']
+    assert snapshot['uuid'] == uuid
+
+
+@pytest.mark.mvp
+def test_snapshot_failed_null_chassis(app: Devicehub, user: UserClient):
+    """ This test check if the file snapshot is create when some snapshot is wrong """
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
+    snapshot_error = file('failed.snapshot.422.null-chassis')
+    uuid = snapshot_error['uuid']
+
+    snapshot = {'software': '', 'version': '', 'uuid': ''}
+    # import pdb; pdb.set_trace()
+    with pytest.raises(TypeError):
+        user.post(res=Snapshot, data=snapshot_error)
+
+    files = [x for x in os.listdir(tmp_snapshots) if uuid in x]
+    if files:
+        path_snapshot = os.path.join(tmp_snapshots, files[0])
+        with open(path_snapshot) as file_snapshot:
+            snapshot = json.loads(file_snapshot.read())
+
+        os.remove(path_snapshot)
+
+    assert snapshot['software'] == snapshot_error['software']
+    assert snapshot['version'] == snapshot_error['version']
+    assert snapshot['uuid'] == uuid
+
+
+@pytest.mark.mvp
+def test_snapshot_failed_missing_chassis(app: Devicehub, user: UserClient):
+    """ This test check if the file snapshot is create when some snapshot is wrong """
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
+    snapshot_error = file('failed.snapshot.422.missing-chassis')
+    uuid = snapshot_error['uuid']
+
+    snapshot = {'software': '', 'version': '', 'uuid': ''}
+    with pytest.raises(TypeError):
+        user.post(res=Snapshot, data=snapshot_error)
+
+    files = [x for x in os.listdir(tmp_snapshots) if uuid in x]
+    if files:
+        path_snapshot = os.path.join(tmp_snapshots, files[0])
+        with open(path_snapshot) as file_snapshot:
+            snapshot = json.loads(file_snapshot.read())
+
+        os.remove(path_snapshot)
+
+    assert snapshot['software'] == snapshot_error['software']
+    assert snapshot['version'] == snapshot_error['version']
+    assert snapshot['uuid'] == uuid
+

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -473,3 +473,16 @@ def test_pc_rating_rate_none(user: UserClient):
 def test_pc_2(user: UserClient):
     s = file('laptop-hp_255_g3_notebook-hewlett-packard-cnd52270fw.snapshot')
     snapshot, _ = user.post(res=Snapshot, data=s)
+
+
+@pytest.mark.one
+def test_backup_snapshot_with_error_500(user: UserClient):
+    snapshot_no_hid = file('basic.snapshot.nohid')
+    response_snapshot, response_status = user.post(res=Snapshot, data=snapshot_no_hid)
+    assert response_snapshot['software'] == 'Workbench'
+    assert response_snapshot['version'] == '11.0b9'
+    assert response_snapshot['uuid'] == '9a3e7485-fdd0-47ce-bcc7-65c55226b598'
+    assert response_snapshot['elapsed'] == 4
+    assert response_snapshot['author']['id'] == user.user['id']
+    assert response_snapshot['severity'] == 'Warning'
+    assert response_status.status_code == 201

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -583,7 +583,6 @@ def test_snapshot_failed_null_chassis(app: Devicehub, user: UserClient):
     uuid = snapshot_error['uuid']
 
     snapshot = {'software': '', 'version': '', 'uuid': ''}
-    # import pdb; pdb.set_trace()
     with pytest.raises(TypeError):
         user.post(res=Snapshot, data=snapshot_error)
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -479,7 +479,7 @@ def test_pc_2(user: UserClient):
     snapshot, _ = user.post(res=Snapshot, data=s)
 
 
-@pytest.mark.ones
+@pytest.mark.mvp
 def test_save_snapshot_in_file():
     """ This test check if works the function save_snapshot_in_file """
     snapshot_no_hid = file('basic.snapshot.nohid')
@@ -506,7 +506,7 @@ def test_backup_snapshot_with_error_500(user: UserClient):
     """ This test check if the file snapshot is create when some snapshot is wrong """
     snapshot_no_hid = file('basic.snapshot.nohid')
     _, response_status = user.post(res=Snapshot, data=snapshot_no_hid)
-    uuid = '9a3e7485-fdd0-47ce-bcc7-65c55226b598'
+    uuid = snapshot_no_hid['uuid']
     files = [x for x in os.listdir(TMP_SNAPSHOTS) if uuid in x]
 
     snapshot = {'software': '', 'version': '', 'uuid': ''}
@@ -517,7 +517,7 @@ def test_backup_snapshot_with_error_500(user: UserClient):
         file_snapshot.close()
         os.remove(path_snapshot)
 
-    assert snapshot['software'] == 'Workbench'
-    assert snapshot['version'] == '11.0b9'
+    assert snapshot['software'] == snapshot_no_hid['software']
+    assert snapshot['version'] == snapshot_no_hid['version']
     assert snapshot['uuid'] == uuid
     assert response_status.status_code == 500

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -481,11 +481,11 @@ def test_pc_2(user: UserClient):
 
 
 @pytest.mark.mvp
-def test_save_snapshot_in_file(app: Devicehub):
+def test_save_snapshot_in_file(app: Devicehub, user: UserClient):
     """ This test check if works the function save_snapshot_in_file """
     tmp_snapshots = app.config['TMP_SNAPSHOTS']
     snapshot_no_hid = file('basic.snapshot.nohid')
-    save_json(snapshot_no_hid, tmp_snapshots)
+    save_json(snapshot_no_hid, tmp_snapshots, user.user['email'])
 
     uuid = snapshot_no_hid['uuid']
     files = [x for x in os.listdir(tmp_snapshots) if uuid in x]

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -491,7 +491,7 @@ def test_save_snapshot_in_file():
 
     snapshot = {'software': '', 'version': '', 'uuid': ''}
     if files:
-        path_snapshot = "{dir}/{file}".format(dir=TMP_SNAPSHOTS, file=files[0])
+        path_snapshot = os.path.join(dir=TMP_SNAPSHOTS, file=files[0])
         file_snapshot = open(path_snapshot)
         snapshot = json.loads(file_snapshot.read())
         file_snapshot.close()
@@ -514,7 +514,7 @@ def test_backup_snapshot_with_errors(user: UserClient):
 
     files = [x for x in os.listdir(TMP_SNAPSHOTS) if uuid in x]
     if files:
-        path_snapshot = "{dir}/{file}".format(dir=TMP_SNAPSHOTS, file=files[0])
+        path_snapshot = os.path.join(dir=TMP_SNAPSHOTS, file=files[0])
         file_snapshot = open(path_snapshot)
         snapshot = json.loads(file_snapshot.read())
         file_snapshot.close()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -491,7 +491,7 @@ def test_save_snapshot_in_file():
 
     snapshot = {'software': '', 'version': '', 'uuid': ''}
     if files:
-        path_snapshot = os.path.join(dir=TMP_SNAPSHOTS, file=files[0])
+        path_snapshot = os.path.join(TMP_SNAPSHOTS, files[0])
         file_snapshot = open(path_snapshot)
         snapshot = json.loads(file_snapshot.read())
         file_snapshot.close()
@@ -514,7 +514,7 @@ def test_backup_snapshot_with_errors(user: UserClient):
 
     files = [x for x in os.listdir(TMP_SNAPSHOTS) if uuid in x]
     if files:
-        path_snapshot = os.path.join(dir=TMP_SNAPSHOTS, file=files[0])
+        path_snapshot = os.path.join(TMP_SNAPSHOTS, files[0])
         file_snapshot = open(path_snapshot)
         snapshot = json.loads(file_snapshot.read())
         file_snapshot.close()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -492,9 +492,9 @@ def test_save_snapshot_in_file():
     snapshot = {'software': '', 'version': '', 'uuid': ''}
     if files:
         path_snapshot = os.path.join(TMP_SNAPSHOTS, files[0])
-        file_snapshot = open(path_snapshot)
-        snapshot = json.loads(file_snapshot.read())
-        file_snapshot.close()
+        with open(path_snapshot) as file_snapshot:
+            snapshot = json.loads(file_snapshot.read())
+
         os.remove(path_snapshot)
 
     assert snapshot['software'] == snapshot_no_hid['software']
@@ -515,9 +515,9 @@ def test_backup_snapshot_with_errors(user: UserClient):
     files = [x for x in os.listdir(TMP_SNAPSHOTS) if uuid in x]
     if files:
         path_snapshot = os.path.join(TMP_SNAPSHOTS, files[0])
-        file_snapshot = open(path_snapshot)
-        snapshot = json.loads(file_snapshot.read())
-        file_snapshot.close()
+        with open(path_snapshot) as file_snapshot:
+            snapshot = json.loads(file_snapshot.read())
+
         os.remove(path_snapshot)
 
     assert snapshot['software'] == snapshot_no_hid['software']


### PR DESCRIPTION
Now a json file is always saved with the snapshot that is sent to the devicehub. If all process it's ok then this file is delete.
The directory where the snapshots reside is "tmp/snapshots"
The json file has this format: "uuid_unixtime.json"
There are a new test file in basic.snapshot.badly_formed.yaml with errors
In tests/test_snapshot.py there are test_backup_snapshot_with_errors. This test is very useful for check and adapt different situations

## Requirements definition
- Error (unprocesable entity: 422).
- Definir JSON name to **know which client has made the request**: 
   **Proposal**: snapshot + username + date (y-m-d).json

## TODO
- [ ] add client username to JSON filename.