### PR TITLE
Bugfix/67 smart result exceeds range

### DIFF
--- a/ereuse_devicehub/resources/action/models.py
+++ b/ereuse_devicehub/resources/action/models.py
@@ -1163,6 +1163,7 @@ class EreusePrice(Price):
     value agreed by a circuit or platform.
     """
     MULTIPLIER = {
+        Computer: 20,
         Desktop: 20,
         Laptop: 30
     }
@@ -1205,7 +1206,7 @@ class EreusePrice(Price):
                 }
             }
         }
-        SCHEMA[Server] = SCHEMA[Desktop]
+        SCHEMA[Server] = SCHEMA[Computer] = SCHEMA[Desktop]
 
         def __init__(self, device, rating_range, role, price: Decimal) -> None:
             cls = device.__class__ if device.__class__ != Server else Desktop

--- a/ereuse_devicehub/resources/action/models.py
+++ b/ereuse_devicehub/resources/action/models.py
@@ -714,8 +714,8 @@ class TestDataStorage(TestMixin, Test):
     power_cycle_count = Column(SmallInteger)
     _reported_uncorrectable_errors = Column('reported_uncorrectable_errors', Integer)
     command_timeout = Column(Integer)
-    current_pending_sector_count = Column(SmallInteger)
-    offline_uncorrectable = Column(SmallInteger)
+    current_pending_sector_count = Column(Integer)
+    offline_uncorrectable = Column(Integer)
     remaining_lifetime_percentage = Column(SmallInteger)
     elapsed = Column(Interval, nullable=False)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -134,6 +134,12 @@ def file(name: str) -> dict:
         return yaml.load(f)
 
 
+def file_workbench(name: str) -> dict:
+    """Opens and parses a YAML file from the ``files`` subdir."""
+    with Path(__file__).parent.joinpath('workbench_files').joinpath(name + '.json').open() as f:
+        return yaml.load(f)
+
+
 @pytest.fixture()
 def tag_id(app: Devicehub) -> str:
     """Creates a tag and returns its id."""

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -333,3 +333,8 @@ def test_david(user: UserClient):
 def test_eresueprice_computer_type(user: UserClient):
     s = file_workbench('computer-type.snapshot')
     snapshot, _ = user.post(res=em.Snapshot, data=s)
+
+@pytest.mark.mvp
+def test_datastorage_results_exceeds_range(user: UserClient):
+    s = file_workbench('smart-failed.snapshot')
+    snapshot, _ = user.post(res=em.Snapshot, data=s)

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -11,7 +11,7 @@ from ereuse_devicehub.resources.action.models import RateComputer, BenchmarkProc
 from ereuse_devicehub.resources.device.exceptions import NeedsId
 from ereuse_devicehub.resources.device.models import Device
 from ereuse_devicehub.resources.tag.model import Tag
-from tests.conftest import file
+from tests.conftest import file, file_workbench
 
 
 @pytest.mark.mvp
@@ -327,4 +327,9 @@ def test_workbench_asus_1001pxd_rate_low(user: UserClient):
 @pytest.mark.mvp
 def test_david(user: UserClient):
     s = file('david.lshw.snapshot')
+    snapshot, _ = user.post(res=em.Snapshot, data=s)
+
+
+def test_eresueprice_computer_type(user: UserClient):
+    s = file_workbench('computer-type.snapshot')
     snapshot, _ = user.post(res=em.Snapshot, data=s)

--- a/tests/test_workbench.py
+++ b/tests/test_workbench.py
@@ -337,4 +337,4 @@ def test_eresueprice_computer_type(user: UserClient):
 @pytest.mark.mvp
 def test_datastorage_results_exceeds_range(user: UserClient):
     s = file_workbench('smart-failed.snapshot')
-    snapshot, _ = user.post(res=em.Snapshot, data=s)
+    snapshot, _ = user.post(res=em.Snapshot, data=s, status=201)

--- a/tests/workbench_files/computer-type.snapshot.json
+++ b/tests/workbench_files/computer-type.snapshot.json
@@ -1,0 +1,135 @@
+{
+  "device": {
+    "manufacturer": "Render",
+    "chassis": "Virtual",
+    "sku": "1234567890",
+    "actions": [
+      {
+        "type": "StressTest",
+        "elapsed": 60,
+        "severity": "Info"
+      },
+      {
+        "type": "BenchmarkRamSysbench",
+        "rate": 47.3516,
+        "elapsed": 47
+      }
+    ],
+    "model": "Pinetrail",
+    "serialNumber": "0123456789",
+    "type": "Computer",
+    "version": "Revision A"
+  },
+  "endTime": "2020-09-11T18:59:14.395622+00:00",
+  "closed": true,
+  "components": [
+    {
+      "model": "NM10/ICH7 Family High Definition Audio Controller",
+      "type": "SoundCard",
+      "manufacturer": "Intel Corporation",
+      "serialNumber": null,
+      "actions": []
+    },
+    {
+      "model": "USB2.0-Camera",
+      "type": "SoundCard",
+      "manufacturer": "Generic",
+      "serialNumber": "200901010001",
+      "actions": []
+    },
+    {
+      "cores": 1,
+      "model": "Intel Atom CPU N455 @ 1.66GHz",
+      "brand": "Atom",
+      "manufacturer": "Intel Corp.",
+      "actions": [
+        {
+          "type": "BenchmarkProcessorSysbench",
+          "rate": 164.4763,
+          "elapsed": 165
+        },
+        {
+          "type": "BenchmarkProcessor",
+          "rate": 6667.6,
+          "elapsed": 0
+        }
+      ],
+      "speed": 1.667,
+      "generation": null,
+      "serialNumber": null,
+      "type": "Processor",
+      "address": 64,
+      "threads": 2
+    },
+    {
+      "format": "SODIMM",
+      "manufacturer": "7576aces",
+      "interface": "DDR3",
+      "actions": [],
+      "model": null,
+      "speed": 667.0,
+      "serialNumber": "7A7B7C7D",
+      "type": "RamModule",
+      "size": 1024.0
+    },
+    {
+      "manufacturer": "Toshiba",
+      "interface": "ATA",
+      "serialNumber": "907HT0RKT",
+      "model": "MK1665GS",
+      "actions": [
+        {
+          "type": "BenchmarkDataStorage",
+          "readSpeed": 81.1,
+          "writeSpeed": 24.6,
+          "elapsed": 14
+        },
+        {
+          "reallocatedSectorCount": 47,
+          "powerCycleCount": 147,
+          "assessment": true,
+          "currentPendingSectorCount": 0,
+          "offlineUncorrectable": 0,
+          "elapsed": 114,
+          "status": "Completed without error",
+          "type": "TestDataStorage",
+          "length": "Short",
+          "lifetime": 98,
+          "severity": "Info"
+        }
+      ],
+      "type": "HardDrive",
+      "size": 160041.88569599998,
+      "variant": "1M"
+    },
+    {
+      "manufacturer": "Intel Corporation",
+      "serialNumber": null,
+      "model": "Atom Processor D4xx/D5xx/N4xx/N5xx Integrated Graphics Controller",
+      "memory": null,
+      "actions": [],
+      "type": "GraphicCard"
+    },
+    {
+      "firewire": 0,
+      "serial": 1,
+      "actions": [],
+      "model": "Pinetrail",
+      "pcmcia": 0,
+      "serialNumber": "400",
+      "usb": 5,
+      "slots": 0,
+      "manufacturer": "Render",
+      "ramMaxSize": 2,
+      "version": "6.00",
+      "biosDate": "2011-02-28T00:00:00",
+      "type": "Motherboard",
+      "ramSlots": 2
+    }
+  ],
+  "elapsed": 11215,
+  "uuid": "426ba7a5-7d73-4555-817e-562cead08e48",
+  "version": "11.0b11",
+  "software": "Workbench",
+  "type": "Snapshot"
+}

--- a/tests/workbench_files/smart-failed.snapshot.json
+++ b/tests/workbench_files/smart-failed.snapshot.json
@@ -1,0 +1,133 @@
+{
+  "elapsed": 295,
+  "device": {
+    "sku": null,
+    "model": "Inspiron 1210",
+    "chassis": "Laptop",
+    "version": "A04",
+    "manufacturer": "Dell Inc.",
+    "actions": [
+      {
+        "elapsed": 60,
+        "type": "StressTest",
+        "severity": "Info"
+      },
+      {
+        "elapsed": 15,
+        "rate": 15.2835,
+        "type": "BenchmarkRamSysbench"
+      }
+    ],
+    "serialNumber": "JGXDVF1",
+    "type": "Laptop"
+  },
+  "closed": true,
+  "uuid": "f6b8a152-7358-44a5-982d-2a23c235fe7b",
+  "software": "Workbench",
+  "version": "11.0b11",
+  "components": [
+    {
+      "actions": [
+        {
+          "elapsed": 0,
+          "rate": 6383.4,
+          "type": "BenchmarkProcessor"
+        },
+        {
+          "elapsed": 172,
+          "rate": 171.7227,
+          "type": "BenchmarkProcessorSysbench"
+        }
+      ],
+      "model": "Intel Atom CPU Z530 @ 1.60GHz",
+      "brand": "Atom",
+      "generation": null,
+      "speed": 1.3330000000000002,
+      "threads": 2,
+      "cores": 1,
+      "manufacturer": "Intel Corp.",
+      "address": 32,
+      "serialNumber": null,
+      "type": "Processor"
+    },
+    {
+      "size": 1024.0,
+      "interface": "DDR2",
+      "model": null,
+      "format": "SODIMM",
+      "manufacturer": null,
+      "actions": [],
+      "serialNumber": null,
+      "type": "RamModule"
+    },
+    {
+      "size": 12.114858378849794,
+      "model": "X332G 121W1 LCD Monitor",
+      "technology": "LCD",
+      "actions": [],
+      "productionDate": "2008-01-06T00:00:00",
+      "resolutionHeight": 800,
+      "resolutionWidth": 1280,
+      "manufacturer": "SEC \"X332G 121W1\"",
+      "refreshRate": 60,
+      "serialNumber": null,
+      "type": "Display"
+    },
+    {
+      "size": 80026.361856,
+      "interface": "ATA",
+      "model": "SAMSUNG HS082HB",
+      "manufacturer": null,
+      "actions": [
+        {
+          "elapsed": 25,
+          "writeSpeed": 14.9,
+          "readSpeed": 36.2,
+          "type": "BenchmarkDataStorage"
+        },
+        {
+          "severity": "Info",
+          "length": "Short",
+          "reallocatedSectorCount": 0,
+          "assessment": true,
+          "powerCycleCount": 2169,
+          "elapsed": 6,
+          "status": "Completed: read failure",
+          "offlineUncorrectable": 182042944,
+          "lifetime": 4634,
+          "currentPendingSectorCount": 473302660,
+          "type": "TestDataStorage"
+        }
+      ],
+      "variant": "0-05",
+      "serialNumber": "S17QJ16QA13332",
+      "type": "HardDrive"
+    },
+    {
+      "type": "GraphicCard",
+      "model": "US15W/US15X SCH Poulsbo Graphics Controller",
+      "manufacturer": "Intel Corporation",
+      "actions": [],
+      "serialNumber": null,
+      "memory": null
+    },
+    {
+      "usb": 4,
+      "biosDate": "2009-05-03T00:00:00",
+      "pcmcia": 0,
+      "manufacturer": "Dell Inc.",
+      "ramSlots": 1,
+      "ramMaxSize": 1,
+      "type": "Motherboard",
+      "model": "0X605H",
+      "serial": 0,
+      "firewire": 0,
+      "version": "A04",
+      "actions": [],
+      "serialNumber": ".JGXDVF1.CN1296191H0074.",
+      "slots": 0
+    }
+  ],
+  "endTime": "2020-09-11T23:16:44.892808+00:00",
+  "type": "Snapshot"
+}


### PR DESCRIPTION
TestDataStorage have some Smallint fields can exceed the range ( > 32767).
In particular, the following variables inside TestDataStorage class:

**current_pending_sector_count = Column(SmallInteger)
offline_uncorrectable = Column(SmaillInteger)**

The best fix would be to declare them as Integers?