### PR TITLE
Bugfix/74 json backup time in name

### DIFF
--- a/ereuse_devicehub/resources/action/views.py
+++ b/ereuse_devicehub/resources/action/views.py
@@ -32,7 +32,7 @@ def save_json(req_json, tmp_snapshots, user):
     month = now.month
     day = now.day
     hour = now.hour
-    minutes = now.min
+    minutes = now.minute
 
     name_file = f"{year}-{month}-{day}-{hour}-{minutes}_{user}_{uuid}.json"
     path_name = os.path.join(tmp_snapshots, name_file)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -493,6 +493,7 @@ def test_save_snapshot_in_file(app: Devicehub, user: UserClient):
     snapshot = {'software': '', 'version': '', 'uuid': ''}
     if files:
         path_snapshot = os.path.join(tmp_snapshots, files[0])
+        assert not "0001-01-01 00:00:00" in path_snapshot
         with open(path_snapshot) as file_snapshot:
             snapshot = json.loads(file_snapshot.read())
 


### PR DESCRIPTION
This fixed not use the utc time.
Now the file name have the correct minutes