### PR TITLE
Bugfix/88 action end time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ ml).
 - [addend] #87 allocate, deallocate and live actions
 - [fixed] #89 save json on disk only for shapshots
 - [addend] #83 add owner_id in all kind of device
+- [fixed] #91 The most old time allow is 1970-01-01

--- a/ereuse_devicehub/resources/action/schemas.py
+++ b/ereuse_devicehub/resources/action/schemas.py
@@ -39,6 +39,12 @@ class Action(Thing):
     parent = NestedOn(s_device.Computer, dump_only=True, description=m.Action.parent_id.comment)
     url = URL(dump_only=True, description=m.Action.url.__doc__)
 
+    @validates_schema
+    def validate_end_time(self, data: dict):
+        if 'end_time' in data:
+            import pdb; pdb.set_trace()
+        pass
+
 
 class ActionWithOneDevice(Action):
     __doc__ = m.ActionWithOneDevice.__doc__

--- a/ereuse_devicehub/resources/action/schemas.py
+++ b/ereuse_devicehub/resources/action/schemas.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from flask import current_app as app
 from marshmallow import Schema as MarshmallowSchema, ValidationError, fields as f, validates_schema
 from marshmallow.fields import Boolean, DateTime, Decimal, Float, Integer, Nested, String, \
@@ -40,10 +41,13 @@ class Action(Thing):
     url = URL(dump_only=True, description=m.Action.url.__doc__)
 
     @validates_schema
-    def validate_end_time(self, data: dict):
-        if 'end_time' in data:
-            import pdb; pdb.set_trace()
-        pass
+    def validate_times(self, data: dict):
+        unix_time = datetime.fromisoformat("1970-01-02 00:00:00+00:00")
+        if 'end_time' in data and data['end_time'] < unix_time:
+            data['end_time'] = unix_time
+
+        if 'start_time' in data and data['start_time'] < unix_time:
+            data['start_time'] = unix_time
 
 
 class ActionWithOneDevice(Action):

--- a/ereuse_devicehub/resources/device/views.py
+++ b/ereuse_devicehub/resources/device/views.py
@@ -143,6 +143,7 @@ class DeviceView(View):
         # Compute query
         query = self.query(args)
         devices = query.paginate(page=args['page'], per_page=30)  # type: Pagination
+        import pdb; pdb.set_trace()
         return things_response(
             self.schema.dump(devices.items, many=True, nested=1),
             devices.page, devices.per_page, devices.total, devices.prev_num, devices.next_num

--- a/ereuse_devicehub/resources/device/views.py
+++ b/ereuse_devicehub/resources/device/views.py
@@ -143,7 +143,6 @@ class DeviceView(View):
         # Compute query
         query = self.query(args)
         devices = query.paginate(page=args['page'], per_page=30)  # type: Pagination
-        import pdb; pdb.set_trace()
         return things_response(
             self.schema.dump(devices.items, many=True, nested=1),
             devices.page, devices.per_page, devices.total, devices.prev_num, devices.next_num

--- a/tests/files/asus-end_time_bug88.snapshot.yaml
+++ b/tests/files/asus-end_time_bug88.snapshot.yaml
@@ -1,0 +1,135 @@
+{
+  "closed": true,
+  "components": [
+  {
+    "actions": [],
+    "manufacturer": "Intel Corporation",
+    "model": "NM10/ICH7 Family High Definition Audio Controller",
+    "serialNumber": null,
+    "type": "SoundCard"
+  },
+  {
+    "actions": [],
+    "manufacturer": "Azurewave",
+    "model": "USB 2.0 UVC VGA WebCam",
+    "serialNumber": "0x0001",
+    "type": "SoundCard"
+  },
+  {
+    "actions": [],
+    "format": "DIMM",
+    "interface": "DDR2",
+    "manufacturer": null,
+    "model": null,
+    "serialNumber": null,
+    "size": 1024,
+    "speed": 667.0,
+    "type": "RamModule"
+  },
+  {
+    "address": 64,
+    "cores": 1,
+    "actions": [
+    {
+      "elapsed": 165,
+      "rate": 164.8342,
+      "type": "BenchmarkProcessorSysbench"
+    },
+    {
+      "elapsed": 0,
+      "rate": 6665.7,
+      "type": "BenchmarkProcessor"
+    }
+    ],
+    "manufacturer": "Intel Corp.",
+    "model": "Intel Atom CPU N455 @ 1.66GHz",
+    "serialNumber": null,
+    "speed": 1.667,
+    "threads": 2,
+    "type": "Processor"
+  },
+  {
+    "actions": [
+    {
+      "elapsed": 16,
+      "readSpeed": 66.2,
+      "type": "BenchmarkDataStorage",
+      "writeSpeed": 21.8
+    }
+    ],
+    "interface": "ATA",
+    "manufacturer": "Hitachi",
+    "model": "HTS54322",
+    "serialNumber": "E2024242CV86HJ",
+    "size": 238475,
+    "type": "HardDrive"
+  },
+  {
+    "actions": [],
+    "manufacturer": "Qualcomm Atheros",
+    "model": "AR9285 Wireless Network Adapter",
+    "serialNumber": "74:2f:68:8b:fd:c8",
+    "type": "NetworkAdapter",
+    "wireless": true
+  },
+  {
+    "actions": [],
+    "manufacturer": "Qualcomm Atheros",
+    "model": "AR8152 v2.0 Fast Ethernet",
+    "serialNumber": "14:da:e9:42:f6:7c",
+    "speed": 100,
+    "type": "NetworkAdapter",
+    "wireless": false
+  },
+  {
+    "actions": [],
+    "manufacturer": "Intel Corporation",
+    "memory": 256.0,
+    "model": "Atom Processor D4xx/D5xx/N4xx/N5xx Integrated Graphics Controller",
+    "serialNumber": null,
+    "type": "GraphicCard"
+  },
+  {
+    "actions": [
+    {
+      "type": "TestBios",
+      "accessRange": "A",
+    }
+    ],
+    "firewire": 0,
+    "manufacturer": "ASUSTeK Computer INC.",
+    "model": "1001PXD",
+    "pcmcia": 0,
+    "serial": 1,
+    "serialNumber": "Eee0123456789",
+    "slots": 2,
+    "type": "Motherboard",
+    "usb": 5
+  }
+  ],
+  "device": {
+    "chassis": "Netbook",
+    "actions": [
+    {
+      "elapsed": 16,
+      "rate": 15.8978,
+      "type": "BenchmarkRamSysbench"
+    },
+    {
+      "appearanceRange": "A",
+      "functionalityRange": "A",
+      "type": "VisualTest"
+    }
+    ],
+    "manufacturer": "ASUSTeK Computer INC.",
+    "model": "1001PXD",
+    "serialNumber": "B8OAAS048286",
+    "type": "Laptop"
+  },
+  "elapsed": 6,
+  "endTime": "0001-01-01 00:00:00+00:00",
+  "software": "Workbench",
+  "type": "Snapshot",
+  "uuid": "7dc4d19c-914e-4652-a381-d641325fb9c2",
+  "version": "11.0a6"
+}

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -3,6 +3,7 @@ import copy
 import pytest
 
 from datetime import datetime, timedelta
+from dateutil.tz import tzutc
 from decimal import Decimal
 from typing import Tuple, Type
 
@@ -556,8 +557,8 @@ def test_deallocate_bad_dates(user: UserClient):
     """ Tests deallocate with bad date of start_time """
     snapshot, _ = user.post(file('basic.snapshot'), res=models.Snapshot)
     device_id = snapshot['device']['id']
-    delta = timedelta(days=30)
-    future = datetime.now() + delta
+    delay  = timedelta(days=30)
+    future = datetime.now().replace(tzinfo=tzutc()) + delay
     post_deallocate = {"startTime": future,
                        "devices": [device_id]
     }

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -503,8 +503,8 @@ def test_allocate_bad_dates(user: UserClient):
     """ Tests allocate """
     snapshot, _ = user.post(file('basic.snapshot'), res=models.Snapshot)
     device_id = snapshot['device']['id']
-    delta = timedelta(days=30)
-    future = datetime.now() + delta
+    delay = timedelta(days=30)
+    future = datetime.now().replace(tzinfo=tzutc()) + delay
     post_request = {"transaction": "ccc", 
                     "finalUserCode": "aabbcc",
                     "name": "John", 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -695,9 +695,31 @@ def test_snapshot_failed_end_time_bug(app: Devicehub, user: UserClient):
     """ This test check if the end_time = 0001-01-01 00:00:00+00:00
     and then we get a /devices, this create a crash
     """
-    snapshot = file('asus-end_time_bug88.snapshot')
-    user.post(res=Snapshot, data=snapshot)
-    devices, _ = user.get("/devices/")
+    snapshot_file = file('asus-end_time_bug88.snapshot')
+    snapshot, _ = user.post(res=Snapshot, data=snapshot_file)
+    device, _ = user.get(res=m.Device, item=snapshot['device']['id'])
+    end_times = [x['endTime'] for x in device['actions']]
+
+    assert '1970-01-02T00:00:00+00:00' in end_times
+    assert not '0001-01-01T00:00:00+00:00' in end_times
+
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
+    shutil.rmtree(tmp_snapshots)
+
+@pytest.mark.mvp
+def test_snapshot_not_failed_end_time_bug(app: Devicehub, user: UserClient):
+    """ This test check if the end_time != 0001-01-01 00:00:00+00:00
+    and then we get a /devices, this create a crash
+    """
+    snapshot_file = file('asus-end_time_bug88.snapshot')
+    snapshot_file['endTime'] = '2001-01-01 00:00:00+00:00'
+    snapshot, _ = user.post(res=Snapshot, data=snapshot_file)
+    device, _ = user.get(res=m.Device, item=snapshot['device']['id'])
+    end_times = [x['endTime'] for x in device['actions']]
+
+    assert not '1970-01-02T00:00:00+00:00' in end_times
+    assert not '0001-01-01T00:00:00+00:00' in end_times
+    assert '2001-01-01T00:00:00+00:00' in end_times
 
     tmp_snapshots = app.config['TMP_SNAPSHOTS']
     shutil.rmtree(tmp_snapshots)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -689,3 +689,15 @@ def test_snapshot_failed_missing_chassis(app: Devicehub, user: UserClient):
     assert snapshot['version'] == snapshot_error['version']
     assert snapshot['uuid'] == uuid
 
+
+@pytest.mark.mvp
+def test_snapshot_failed_end_time_bug(app: Devicehub, user: UserClient):
+    """ This test check if the end_time = 0001-01-01 00:00:00+00:00
+    and then we get a /devices, this create a crash
+    """
+    snapshot = file('asus-end_time_bug88.snapshot')
+    user.post(res=Snapshot, data=snapshot)
+    devices, _ = user.get("/devices/")
+
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
+    shutil.rmtree(tmp_snapshots)


### PR DESCRIPTION
The bug is in: [issues 88](https://github.com/eReuse/devicehub-teal/issues/88)

The real problem is in datetime:
https://bugs.python.org/issue31212
For reproduce this bug:
t = datetime.fromisoformat("0001-01-01 00:00:00+00:00")
t.timestamp()
or
```
>>> t = datetime.fromisoformat("0001-01-01 00:00:00")
>>> t
datetime.datetime(1, 1, 1, 0, 0)
>>> t.timestamp()
Traceback (most recent call last):
  File "<console>", line 1, in <module>
ValueError: year 0 is out of range
```

Now we replace all date before of 1970-01-01 for 1970-01-01
This behaviour is activate for start_time and end_time

There are 2 tests than check this problem