### PR TITLE
Change/#92 #93 drop nullable

### DIFF
--- a/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
+++ b/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
@@ -1,0 +1,35 @@
+"""empty message
+
+Revision ID: 378b6b147b46
+Revises: bf600ca861a4
+Create Date: 2020-12-16 11:45:13.339624
+
+"""
+from alembic import context
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+import citext
+import teal
+
+
+# revision identifiers, used by Alembic.
+revision = '378b6b147b46'
+down_revision = 'bf600ca861a4'
+branch_labels = None
+depends_on = None
+
+
+def get_inv():
+    INV = context.get_x_argument(as_dictionary=True).get('inventory')
+    if not INV:
+        raise ValueError("Inventory value is not specified")
+    return INV
+
+def upgrade():
+    op.alter_column('{get_inv()}.computer', 'chassis', nullable=True)
+    # pass
+
+
+def downgrade():
+    pass

--- a/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
+++ b/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
@@ -31,6 +31,9 @@ def upgrade():
     op.alter_column('display', 'size', nullable=True, schema=f'{get_inv()}')
     op.alter_column('display', 'resolution_width', nullable=True, schema=f'{get_inv()}')
     op.alter_column('display', 'resolution_height', nullable=True, schema=f'{get_inv()}')
+    op.alter_column('monitor', 'size', nullable=True, schema=f'{get_inv()}')
+    op.alter_column('monitor', 'resolution_width', nullable=True, schema=f'{get_inv()}')
+    op.alter_column('monitor', 'resolution_height', nullable=True, schema=f'{get_inv()}')
     # pass
 
 

--- a/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
+++ b/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
@@ -27,7 +27,7 @@ def get_inv():
     return INV
 
 def upgrade():
-    op.alter_column('{get_inv()}.computer', 'chassis', nullable=True)
+    op.alter_column('computer', 'chassis', nullable=True, schema=f'{get_inv()}')
     # pass
 
 

--- a/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
+++ b/ereuse_devicehub/migrations/versions/378b6b147b46_nullable.py
@@ -28,6 +28,9 @@ def get_inv():
 
 def upgrade():
     op.alter_column('computer', 'chassis', nullable=True, schema=f'{get_inv()}')
+    op.alter_column('display', 'size', nullable=True, schema=f'{get_inv()}')
+    op.alter_column('display', 'resolution_width', nullable=True, schema=f'{get_inv()}')
+    op.alter_column('display', 'resolution_height', nullable=True, schema=f'{get_inv()}')
     # pass
 
 

--- a/ereuse_devicehub/resources/action/schemas.py
+++ b/ereuse_devicehub/resources/action/schemas.py
@@ -260,9 +260,8 @@ class TestBios(Test):
 
 class VisualTest(Test):
     __doc__ = m.VisualTest.__doc__
-    appearance_range = EnumField(AppearanceRange, required=True, data_key='appearanceRange')
+    appearance_range = EnumField(AppearanceRange, data_key='appearanceRange')
     functionality_range = EnumField(FunctionalityRange,
-                                    required=True,
                                     data_key='functionalityRange')
     labelling = Boolean()
 

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -342,19 +342,19 @@ class Device(Thing):
 
 class DisplayMixin:
     """Base class for the Display Component and the Monitor Device."""
-    size = Column(Float(decimal_return_scale=1), check_range('size', 2, 150), nullable=False)
+    size = Column(Float(decimal_return_scale=1), check_range('size', 2, 150), nullable=True)
     size.comment = """The size of the monitor in inches."""
     technology = Column(DBEnum(DisplayTech))
     technology.comment = """The technology the monitor uses to display
     the image.
     """
     resolution_width = Column(SmallInteger, check_range('resolution_width', 10, 20000),
-                              nullable=False)
+                              nullable=True)
     resolution_width.comment = """The maximum horizontal resolution the
     monitor can natively support in pixels.
     """
     resolution_height = Column(SmallInteger, check_range('resolution_height', 10, 20000),
-                               nullable=False)
+                               nullable=True)
     resolution_height.comment = """The maximum vertical resolution the
     monitor can natively support in pixels.
     """

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -430,9 +430,12 @@ class Computer(Device):
     receiver = db.relationship(User, primaryjoin=receiver_id == User.id)
     deliverynote_address = db.Column(CIText(), nullable=True)
 
-    def __init__(self, chassis, **kwargs) -> None:
-        chassis = ComputerChassis(chassis)
-        super().__init__(chassis=chassis, **kwargs)
+    def __init__(self, *args, **kwargs) -> None:
+        if args:
+            chassis = ComputerChassis(args[0])
+            super().__init__(chassis=chassis, **kwargs)
+        else:
+            super().__init__(*args, **kwargs)
 
     @property
     def actions(self) -> list:

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -372,15 +372,14 @@ class DisplayMixin:
         """
         if self.resolution_height and self.resolution_width:
             return Fraction(self.resolution_width, self.resolution_height)
+        return 0
 
     # noinspection PyUnresolvedReferences
     @aspect_ratio.expression
     def aspect_ratio(cls):
         # The aspect ratio to use as SQL in the DB
         # This allows comparing resolutions
-        if cls.resolution_height and cls.resolution_width:
-            return db.func.round(cls.resolution_width / cls.resolution_height, 2)
-        return 4/3
+        return db.func.round(cls.resolution_width / cls.resolution_height, 2)
 
     @hybrid_property
     def widescreen(self):

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -410,7 +410,7 @@ class Computer(Device):
     ``Server``. The property ``chassis`` defines it more granularly.
     """
     id = Column(BigInteger, ForeignKey(Device.id), primary_key=True)
-    chassis = Column(DBEnum(ComputerChassis), nullable=False)
+    chassis = Column(DBEnum(ComputerChassis), nullable=True)
     chassis.comment = """The physical form of the computer.
 
     It is a subset of the Linux definition of DMI / DMI decode.

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -370,14 +370,17 @@ class DisplayMixin:
         Regular values are ``4/3``, ``5/4``, ``16/9``, ``21/9``,
         ``14/10``, ``19/10``, ``16/10``.
         """
-        return Fraction(self.resolution_width, self.resolution_height)
+        if self.resolution_height and self.resolution_width:
+            return Fraction(self.resolution_width, self.resolution_height)
 
     # noinspection PyUnresolvedReferences
     @aspect_ratio.expression
     def aspect_ratio(cls):
         # The aspect ratio to use as SQL in the DB
         # This allows comparing resolutions
-        return db.func.round(cls.resolution_width / cls.resolution_height, 2)
+        if cls.resolution_height and cls.resolution_width:
+            return db.func.round(cls.resolution_width / cls.resolution_height, 2)
+        return 4/3
 
     @hybrid_property
     def widescreen(self):
@@ -390,7 +393,9 @@ class DisplayMixin:
         return self.aspect_ratio > 4.001 / 3
 
     def __str__(self) -> str:
-        return '{0.t} {0.serial_number} {0.size}in ({0.aspect_ratio}) {0.technology}'.format(self)
+        if self.size:
+            return '{0.t} {0.serial_number} {0.size}in ({0.aspect_ratio}) {0.technology}'.format(self)
+        return '{0.t} {0.serial_number} 0in ({0.aspect_ratio}) {0.technology}'.format(self)
 
     def __format__(self, format_spec: str) -> str:
         v = ''
@@ -398,7 +403,10 @@ class DisplayMixin:
             v += '{0.t} {0.model}'.format(self)
         if 's' in format_spec:
             v += '({0.manufacturer}) S/N {0.serial_number}'.format(self)
-            v += '– {0.size}in ({0.aspect_ratio}) {0.technology}'.format(self)
+            if self.size:
+                v += '– {0.size}in ({0.aspect_ratio}) {0.technology}'.format(self)
+            else:
+                v += '– 0in ({0.aspect_ratio}) {0.technology}'.format(self)
         return v
 
 

--- a/ereuse_devicehub/resources/device/schemas.py
+++ b/ereuse_devicehub/resources/device/schemas.py
@@ -148,17 +148,17 @@ class Server(Computer):
 
 class DisplayMixin:
     __doc__ = m.DisplayMixin.__doc__
-    size = Float(description=m.DisplayMixin.size.comment, validate=Range(2, 150), required=True)
+    size = Float(description=m.DisplayMixin.size.comment, validate=Range(2, 150))
     technology = EnumField(enums.DisplayTech,
                            description=m.DisplayMixin.technology.comment)
     resolution_width = Integer(data_key='resolutionWidth',
                                validate=Range(10, 20000),
                                description=m.DisplayMixin.resolution_width.comment,
-                               required=True)
+                               )
     resolution_height = Integer(data_key='resolutionHeight',
                                 validate=Range(10, 20000),
                                 description=m.DisplayMixin.resolution_height.comment,
-                                required=True)
+                                )
     refresh_rate = Integer(data_key='refreshRate', validate=Range(10, 1000))
     contrast_ratio = Integer(data_key='contrastRatio', validate=Range(100, 100000))
     touchable = Boolean(description=m.DisplayMixin.touchable.comment)

--- a/ereuse_devicehub/resources/device/schemas.py
+++ b/ereuse_devicehub/resources/device/schemas.py
@@ -101,7 +101,7 @@ class Computer(Device):
                           collection_class=OrderedSet,
                           description='The components that are inside this computer.')
     chassis = EnumField(enums.ComputerChassis,
-                        required=False,
+                        required=True,
                         description=m.Computer.chassis.comment)
     ram_size = Integer(dump_only=True,
                        data_key='ramSize',

--- a/ereuse_devicehub/resources/device/schemas.py
+++ b/ereuse_devicehub/resources/device/schemas.py
@@ -101,7 +101,7 @@ class Computer(Device):
                           collection_class=OrderedSet,
                           description='The components that are inside this computer.')
     chassis = EnumField(enums.ComputerChassis,
-                        required=True,
+                        required=False,
                         description=m.Computer.chassis.comment)
     ram_size = Integer(dump_only=True,
                        data_key='ramSize',

--- a/ereuse_devicehub/resources/device/schemas.py
+++ b/ereuse_devicehub/resources/device/schemas.py
@@ -101,7 +101,6 @@ class Computer(Device):
                           collection_class=OrderedSet,
                           description='The components that are inside this computer.')
     chassis = EnumField(enums.ComputerChassis,
-                        required=True,
                         description=m.Computer.chassis.comment)
     ram_size = Integer(dump_only=True,
                        data_key='ramSize',

--- a/ereuse_devicehub/resources/device/search.py
+++ b/ereuse_devicehub/resources/device/search.py
@@ -112,16 +112,27 @@ class DeviceSearch(db.Model):
         if isinstance(device, Computer):
             # Aggregate the values of all the components of pc
             Comp = aliased(Component)
-            tokens.extend((
-                (db.func.string_agg(db.cast(Comp.id, db.TEXT), ' '), search.Weight.D),
-                (db.func.string_agg(Comp.model, ' '), search.Weight.C),
-                (db.func.string_agg(Comp.manufacturer, ' '), search.Weight.D),
-                (db.func.string_agg(Comp.serial_number, ' '), search.Weight.B),
-                (db.func.string_agg(Comp.type, ' '), search.Weight.B),
-                ('Computer', search.Weight.C),
-                ('PC', search.Weight.C),
-                (inflection.humanize(device.chassis.name), search.Weight.B),
-            ))
+            if device.chassis:
+                tokens.extend((
+                    (db.func.string_agg(db.cast(Comp.id, db.TEXT), ' '), search.Weight.D),
+                    (db.func.string_agg(Comp.model, ' '), search.Weight.C),
+                    (db.func.string_agg(Comp.manufacturer, ' '), search.Weight.D),
+                    (db.func.string_agg(Comp.serial_number, ' '), search.Weight.B),
+                    (db.func.string_agg(Comp.type, ' '), search.Weight.B),
+                    ('Computer', search.Weight.C),
+                    ('PC', search.Weight.C),
+                    (inflection.humanize(device.chassis.name), search.Weight.B),
+                ))
+            else:
+                tokens.extend((
+                    (db.func.string_agg(db.cast(Comp.id, db.TEXT), ' '), search.Weight.D),
+                    (db.func.string_agg(Comp.model, ' '), search.Weight.C),
+                    (db.func.string_agg(Comp.manufacturer, ' '), search.Weight.D),
+                    (db.func.string_agg(Comp.serial_number, ' '), search.Weight.B),
+                    (db.func.string_agg(Comp.type, ' '), search.Weight.B),
+                    ('Computer', search.Weight.C),
+                    ('PC', search.Weight.C),
+                ))
 
         properties = session \
             .query(search.Search.vectorize(*tokens)) \

--- a/ereuse_devicehub/resources/device/search.py
+++ b/ereuse_devicehub/resources/device/search.py
@@ -112,27 +112,15 @@ class DeviceSearch(db.Model):
         if isinstance(device, Computer):
             # Aggregate the values of all the components of pc
             Comp = aliased(Component)
-            if device.chassis:
-                tokens.extend((
-                    (db.func.string_agg(db.cast(Comp.id, db.TEXT), ' '), search.Weight.D),
-                    (db.func.string_agg(Comp.model, ' '), search.Weight.C),
-                    (db.func.string_agg(Comp.manufacturer, ' '), search.Weight.D),
-                    (db.func.string_agg(Comp.serial_number, ' '), search.Weight.B),
-                    (db.func.string_agg(Comp.type, ' '), search.Weight.B),
-                    ('Computer', search.Weight.C),
-                    ('PC', search.Weight.C),
-                    (inflection.humanize(device.chassis.name), search.Weight.B),
-                ))
-            else:
-                tokens.extend((
-                    (db.func.string_agg(db.cast(Comp.id, db.TEXT), ' '), search.Weight.D),
-                    (db.func.string_agg(Comp.model, ' '), search.Weight.C),
-                    (db.func.string_agg(Comp.manufacturer, ' '), search.Weight.D),
-                    (db.func.string_agg(Comp.serial_number, ' '), search.Weight.B),
-                    (db.func.string_agg(Comp.type, ' '), search.Weight.B),
-                    ('Computer', search.Weight.C),
-                    ('PC', search.Weight.C),
-                ))
+            tokens.extend((
+                (db.func.string_agg(db.cast(Comp.id, db.TEXT), ' '), search.Weight.D),
+                (db.func.string_agg(Comp.model, ' '), search.Weight.C),
+                (db.func.string_agg(Comp.manufacturer, ' '), search.Weight.D),
+                (db.func.string_agg(Comp.serial_number, ' '), search.Weight.B),
+                (db.func.string_agg(Comp.type, ' '), search.Weight.B),
+                ('Computer', search.Weight.C),
+                ('PC', search.Weight.C),
+            ))
 
         properties = session \
             .query(search.Search.vectorize(*tokens)) \

--- a/ereuse_devicehub/resources/enums.py
+++ b/ereuse_devicehub/resources/enums.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from enum import Enum, IntEnum, unique, EnumMeta
+from enum import Enum, IntEnum, unique
 from typing import Set, Union
 
 import inflection
@@ -207,20 +207,9 @@ class DisplayTech(Enum):
         return self.name
 
 
-class DefaultEnumMeta(EnumMeta):
-    default = object()
-
-    def __call__(cls, value=default, *args, **kwargs):
-        # import pdb; pdb.set_trace()
-        if value is DefaultEnumMeta.default:
-            # Assume the first enum is default
-            return next(iter(cls))
-        return super().__call__(value, *args, **kwargs)
-
 @unique
-class ComputerChassis(Enum, metaclass=DefaultEnumMeta):
+class ComputerChassis(Enum):
     """The chassis of a computer."""
-    Nothing = None
     Tower = 'Tower'
     Docking = 'Docking'
     AllInOne = 'All in one'

--- a/ereuse_devicehub/resources/enums.py
+++ b/ereuse_devicehub/resources/enums.py
@@ -1,5 +1,5 @@
 from contextlib import suppress
-from enum import Enum, IntEnum, unique
+from enum import Enum, IntEnum, unique, EnumMeta
 from typing import Set, Union
 
 import inflection
@@ -207,9 +207,20 @@ class DisplayTech(Enum):
         return self.name
 
 
+class DefaultEnumMeta(EnumMeta):
+    default = object()
+
+    def __call__(cls, value=default, *args, **kwargs):
+        # import pdb; pdb.set_trace()
+        if value is DefaultEnumMeta.default:
+            # Assume the first enum is default
+            return next(iter(cls))
+        return super().__call__(value, *args, **kwargs)
+
 @unique
-class ComputerChassis(Enum):
+class ComputerChassis(Enum, metaclass=DefaultEnumMeta):
     """The chassis of a computer."""
+    Nothing = None
     Tower = 'Tower'
     Docking = 'Docking'
     AllInOne = 'All in one'

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -684,7 +684,7 @@ def test_snapshot_not_failed_null_chassis(app: Devicehub, user: UserClient):
     tmp_snapshots = app.config['TMP_SNAPSHOTS']
     path_dir_base = os.path.join(tmp_snapshots, user.user['email'], 'errors')
     snapshot_error = file('desktop-9644w8n-lenovo-0169622.snapshot')
-    snapshot_error['device']['chassis'] = 'Nothing'
+    snapshot_error['device']['chassis'] = None 
     uuid = snapshot_error['uuid']
 
     snapshot, res = user.post(res=Snapshot, data=snapshot_error)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -679,24 +679,17 @@ def test_snapshot_failed_missing_hdd_benchmark(app: Devicehub, user: UserClient)
 
 
 @pytest.mark.mvp
-def test_snapshot_failed_null_chassis(app: Devicehub, user: UserClient):
+def test_snapshot_not_failed_null_chassis(app: Devicehub, user: UserClient):
     """ This test check if the file snapshot is create when some snapshot is wrong """
     tmp_snapshots = app.config['TMP_SNAPSHOTS']
     path_dir_base = os.path.join(tmp_snapshots, user.user['email'], 'errors')
-    snapshot_error = file('failed.snapshot.422.null-chassis')
+    snapshot_error = file('desktop-9644w8n-lenovo-0169622.snapshot')
+    snapshot_error['device']['chassis'] = 'Nothing'
     uuid = snapshot_error['uuid']
 
-    snapshot = {'software': '', 'version': '', 'uuid': ''}
-    with pytest.raises(TypeError):
-        user.post(res=Snapshot, data=snapshot_error)
+    snapshot, res = user.post(res=Snapshot, data=snapshot_error)
 
-    files = [x for x in os.listdir(path_dir_base) if uuid in x]
-    if files:
-        path_snapshot = os.path.join(path_dir_base, files[0])
-        with open(path_snapshot) as file_snapshot:
-            snapshot = json.loads(file_snapshot.read())
-
-        shutil.rmtree(tmp_snapshots)
+    shutil.rmtree(tmp_snapshots)
 
     assert snapshot['software'] == snapshot_error['software']
     assert snapshot['version'] == snapshot_error['version']


### PR DESCRIPTION
This pull request depend with this other pull request of DeviceHubClient
https://github.com/eReuse/DeviceHubClient/pull/65

* https://github.com/eReuse/devicehub-teal/issues/93
* https://github.com/eReuse/devicehub-teal/issues/92
* put functionality and appearance as not required too
* clean the types of this form for show only the necessary types of devices

Remember reset the database and next do a migration like this:
git checkout testing
dropdb -U postgres devicehub
sh examples/create-db.sh devicehub
export dhi=dbtest; dh inv add --common --name dbtest
alembic stamp head
alembic -x inventory=dbtest upgrade head
dh dummy --yes
git checkout change/#92-#93-drop-nullable
alembic -x inventory=dbtest upgrade head