### PR TITLE
Feature/#95 endpoint check hash reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ml).
 
 ## master
-  [1.0.1-beta]
+  [1.0.2-beta]
 
 ## testing
   [1.0.3-beta]
 
 ## [1.0.3-beta]
 - [addend] #85 add mac of network adapter to device hid
+- [addend] #95 adding endpoint for check the hash of one report
 - [changed] #94 change form of snapshot manual
 
 ## [1.0.2-beta]

--- a/ereuse_devicehub/migrations/versions/3eb50297c365_add_hash.py
+++ b/ereuse_devicehub/migrations/versions/3eb50297c365_add_hash.py
@@ -5,12 +5,13 @@ Revises: 378b6b147b46
 Create Date: 2020-12-18 16:26:15.453694
 
 """
-from alembic import context
-from alembic import op
-import sqlalchemy as sa
-import sqlalchemy_utils
+
 import citext
-import teal
+import sqlalchemy as sa
+
+from alembic import op
+from alembic import context
+from sqlalchemy.dialects import postgresql
 
 
 # revision identifiers, used by Alembic.
@@ -29,10 +30,10 @@ def get_inv():
 def upgrade():
     # Report Hash table
     op.create_table('report_hash',
-                    sa.Column('id', sa.BigInteger(), nullable=False),
+                    sa.Column('id', postgresql.UUID(as_uuid=True), nullable=False),
                     sa.Column('created', sa.TIMESTAMP(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'),
                               nullable=False, comment='When Devicehub created this.'),
-                    sa.Column('hash', citext.CIText(), nullable=False),
+                    sa.Column('hash3', citext.CIText(), nullable=False),
                     sa.PrimaryKeyConstraint('id'),
                     schema=f'{get_inv()}'
                     )

--- a/ereuse_devicehub/migrations/versions/3eb50297c365_add_hash.py
+++ b/ereuse_devicehub/migrations/versions/3eb50297c365_add_hash.py
@@ -1,0 +1,42 @@
+"""empty message
+
+Revision ID: 3eb50297c365
+Revises: 378b6b147b46
+Create Date: 2020-12-18 16:26:15.453694
+
+"""
+from alembic import context
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+import citext
+import teal
+
+
+# revision identifiers, used by Alembic.
+revision = '3eb50297c365'
+down_revision = '378b6b147b46'
+branch_labels = None
+depends_on = None
+
+
+def get_inv():
+    INV = context.get_x_argument(as_dictionary=True).get('inventory')
+    if not INV:
+        raise ValueError("Inventory value is not specified")
+    return INV
+
+def upgrade():
+    # Report Hash table
+    op.create_table('report_hash',
+                    sa.Column('id', sa.BigInteger(), nullable=False),
+                    sa.Column('created', sa.TIMESTAMP(timezone=True), server_default=sa.text('CURRENT_TIMESTAMP'),
+                              nullable=False, comment='When Devicehub created this.'),
+                    sa.Column('hash', citext.CIText(), nullable=False),
+                    sa.PrimaryKeyConstraint('id'),
+                    schema=f'{get_inv()}'
+                    )
+
+
+def downgrade():
+    op.drop_table('report_hash', schema=f'{get_inv()}')

--- a/ereuse_devicehub/resources/documents/documents.py
+++ b/ereuse_devicehub/resources/documents/documents.py
@@ -23,6 +23,7 @@ from ereuse_devicehub.resources.documents.device_row import DeviceRow, StockRow
 from ereuse_devicehub.resources.documents.device_row import DeviceRow
 from ereuse_devicehub.resources.lot import LotView
 from ereuse_devicehub.resources.lot.models import Lot
+from ereuse_devicehub.resources.hash_reports import insert_hash
 
 
 
@@ -125,7 +126,9 @@ class DevicesDocumentView(DeviceView):
                 cw.writerow(d.keys())
                 first = False
             cw.writerow(d.values())
-        output = make_response(data.getvalue().encode('utf-8'))
+        bfile = data.getvalue().encode('utf-8')
+        insert_hash(bfile)
+        output = make_response(bfile)
         output.headers['Content-Disposition'] = 'attachment; filename=export.csv'
         output.headers['Content-type'] = 'text/csv'
         return output

--- a/ereuse_devicehub/resources/documents/documents.py
+++ b/ereuse_devicehub/resources/documents/documents.py
@@ -117,7 +117,7 @@ class DevicesDocumentView(DeviceView):
     def generate_post_csv(self, query):
         """Get device query and put information in csv format."""
         data = StringIO()
-        cw = csv.writer(data, delimiter=';', quotechar='"')
+        cw = csv.writer(data, delimiter=';', lineterminator="\n", quotechar='"')
         first = True
         for device in query:
             d = DeviceRow(device)
@@ -126,8 +126,8 @@ class DevicesDocumentView(DeviceView):
                 first = False
             cw.writerow(d.values())
         bfile = data.getvalue().encode('utf-8')
-        insert_hash(bfile)
         output = make_response(bfile)
+        insert_hash(bfile)
         output.headers['Content-Disposition'] = 'attachment; filename=export.csv'
         output.headers['Content-type'] = 'text/csv'
         return output
@@ -197,10 +197,10 @@ class CheckView(View):
 
     def get(self):
         qry = dict(request.values)
-        hash3 = qry['hash']
+        hash3 = qry.get('hash')
 
         result = False
-        if ReportHash.query.filter_by(hash3=hash3).count():
+        if hash3 and ReportHash.query.filter_by(hash3=hash3).count():
             result = True
         return jsonify(result)
 

--- a/ereuse_devicehub/resources/hash_reports.py
+++ b/ereuse_devicehub/resources/hash_reports.py
@@ -1,0 +1,29 @@
+"""Hash implementation and save in database 
+"""
+import hashlib
+
+from citext import CIText
+from sqlalchemy import Column
+from sqlalchemy.dialects.postgresql import UUID
+from uuid import uuid4
+
+from ereuse_devicehub.db import db
+
+
+class ReportHash(db.Model):
+    """Save the hash than is create when one report is download.
+    """
+    id = Column(UUID(as_uuid=True), primary_key=True, default=uuid4)
+    id.comment = """The identifier of the device for this database. Used only
+    internally for software; users should not use this.
+    """
+    hash3 = db.Column(CIText(), nullable=False)
+    hash3.comment = """The normalized name of the hash."""
+
+
+def insert_hash(bfile=b'hello'):
+    hash3 = hashlib.sha3_256(bfile).hexdigest()
+    db_hash = ReportHash(hash3=hash3)
+    db.session.add(db_hash)
+    db.session.commit()
+    db.session.flush()

--- a/ereuse_devicehub/resources/hash_reports.py
+++ b/ereuse_devicehub/resources/hash_reports.py
@@ -21,7 +21,7 @@ class ReportHash(db.Model):
     hash3.comment = """The normalized name of the hash."""
 
 
-def insert_hash(bfile=b'hello'):
+def insert_hash(bfile):
     hash3 = hashlib.sha3_256(bfile).hexdigest()
     db_hash = ReportHash(hash3=hash3)
     db.session.add(db_hash)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -53,6 +53,7 @@ def test_api_docs(client: Client):
         '/documents/lots/',
         '/documents/static/{filename}',
         '/documents/stock/',
+        '/documents/check/',
         '/drills/{dev1_id}/merge/{dev2_id}',
         '/graphic-cards/{dev1_id}/merge/{dev2_id}',
         '/hard-drives/{dev1_id}/merge/{dev2_id}',

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -144,6 +144,9 @@ def test_check_insert_hash(app: Devicehub, user: UserClient):
                           query=[('filter', {'type': ['Computer']})])
     hash3 = hashlib.sha3_256(csv_str.encode('utf-8')).hexdigest()
     assert ReportHash.query.filter_by(hash3=hash3).count() == 1
+    result, status = user.get(res=documents.DocumentDef.t, item='check/', query=[('hash', hash3)])
+    assert status.status_code == 200
+    assert result == True
 
 
 @pytest.mark.mvp

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,4 +1,5 @@
 import csv
+import hashlib
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
@@ -15,7 +16,9 @@ from ereuse_devicehub.resources.documents import documents
 from ereuse_devicehub.resources.device import models as d
 from ereuse_devicehub.resources.lot.models import Lot
 from ereuse_devicehub.resources.tag.model import Tag
+from ereuse_devicehub.resources.hash_reports import ReportHash
 from ereuse_devicehub.db import db
+from tests import conftest
 from tests.conftest import file
 
 
@@ -103,6 +106,7 @@ def test_export_csv_permitions(user: UserClient, user2: UserClient, client: Clie
     assert len(csv_user) > 0
     assert len(csv_user2) == 0
 
+
 @pytest.mark.mvp
 def test_export_basic_snapshot(user: UserClient):
     """Test export device information in a csv file."""
@@ -127,6 +131,20 @@ def test_export_basic_snapshot(user: UserClient):
     assert fixture_csv[1][:17] == export_csv[1][:17], 'Computer information are not equal'
     assert fixture_csv[1][18] == export_csv[1][18], 'Computer information are not equal'
     assert fixture_csv[1][20:] == export_csv[1][20:], 'Computer information are not equal'
+
+
+@pytest.mark.mvp
+@pytest.mark.usefixtures(conftest.app_context.__name__)
+def test_check_insert_hash(app: Devicehub, user: UserClient):
+    """Test export device information in a csv file."""
+    snapshot, _ = user.post(file('basic.snapshot'), res=Snapshot)
+    csv_str, _ = user.get(res=documents.DocumentDef.t,
+                          item='devices/',
+                          accept='text/csv',
+                          query=[('filter', {'type': ['Computer']})])
+    hash3 = hashlib.sha3_256(csv_str.encode('utf-8')).hexdigest()
+    assert ReportHash.query.filter_by(hash3=hash3).count() == 1
+
 
 @pytest.mark.mvp
 def test_export_extended(app: Devicehub, user: UserClient):

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -135,7 +135,7 @@ def test_export_basic_snapshot(user: UserClient):
 
 @pytest.mark.mvp
 @pytest.mark.usefixtures(conftest.app_context.__name__)
-def test_check_insert_hash(app: Devicehub, user: UserClient):
+def test_check_insert_hash(app: Devicehub, user: UserClient, client: Client):
     """Test export device information in a csv file."""
     snapshot, _ = user.post(file('basic.snapshot'), res=Snapshot)
     csv_str, _ = user.get(res=documents.DocumentDef.t,
@@ -144,9 +144,16 @@ def test_check_insert_hash(app: Devicehub, user: UserClient):
                           query=[('filter', {'type': ['Computer']})])
     hash3 = hashlib.sha3_256(csv_str.encode('utf-8')).hexdigest()
     assert ReportHash.query.filter_by(hash3=hash3).count() == 1
-    result, status = user.get(res=documents.DocumentDef.t, item='check/', query=[('hash', hash3)])
+    result, status = client.get(res=documents.DocumentDef.t, item='check/', query=[('hash', hash3)])
     assert status.status_code == 200
     assert result == True
+
+    ff = open('/tmp/test.csv', 'w')
+    ff.write(csv_str)
+    ff.close()
+
+    a= open('/tmp/test.csv').read()
+    assert hash3 == hashlib.sha3_256(a.encode('utf-8')).hexdigest()
 
 
 @pytest.mark.mvp


### PR DESCRIPTION
https://github.com/eReuse/devicehub-teal/issues/95

The check point is "/documents/check/", the method is GET and the params is like this:
```
hash=80084bf2fba02475726feb2cab2d8215eab14bc6bdd8bfb2c8151257032ecd8b
```
When you download a csv report if you have a unix or linux operating system, the line break is:
```
\n
```
but if you have windows the line break is:
```
\n
```
I don't know if the system check get the line break as windows or unix style