### PR TITLE
Bugfix/bug #1998

### DIFF
--- a/ereuse_devicehub/migrations/versions/0cbd839b09ef_change_testdatastorage_smallint_for_.py
+++ b/ereuse_devicehub/migrations/versions/0cbd839b09ef_change_testdatastorage_smallint_for_.py
@@ -1,0 +1,36 @@
+"""change TestDataStorage SmallInt for Integer
+
+Revision ID: 0cbd839b09ef
+Revises: b4bd1538bad5
+Create Date: 2021-01-21 12:53:21.996221
+
+"""
+from alembic import context
+from alembic import op
+import sqlalchemy as sa
+import sqlalchemy_utils
+import citext
+import teal
+
+
+# revision identifiers, used by Alembic.
+revision = '0cbd839b09ef'
+down_revision = 'b4bd1538bad5'
+branch_labels = None
+depends_on = None
+
+
+def get_inv():
+    INV = context.get_x_argument(as_dictionary=True).get('inventory')
+    if not INV:
+        raise ValueError("Inventory value is not specified")
+    return INV
+
+def upgrade():
+    op.alter_column('test_data_storage', 'current_pending_sector_count', type_=sa.Integer(), schema=f'{get_inv()}')
+    op.alter_column('test_data_storage', 'offline_uncorrectable', type_=sa.Integer(), schema=f'{get_inv()}')
+
+
+def downgrade():
+    op.alter_column('test_data_storage', 'current_pending_sector_count', type_=sa.SmallInteger(), schema=f'{get_inv()}')
+    op.alter_column('test_data_storage', 'offline_uncorrectable', type_=sa.SmallInteger(), schema=f'{get_inv()}')

--- a/ereuse_devicehub/resources/action/models.py
+++ b/ereuse_devicehub/resources/action/models.py
@@ -742,8 +742,8 @@ class TestDataStorage(TestMixin, Test):
     power_cycle_count = Column(SmallInteger)
     _reported_uncorrectable_errors = Column('reported_uncorrectable_errors', Integer)
     command_timeout = Column(Integer)
-    current_pending_sector_count = Column(SmallInteger)
-    offline_uncorrectable = Column(SmallInteger)
+    current_pending_sector_count = Column(Integer)
+    offline_uncorrectable = Column(Integer)
     remaining_lifetime_percentage = Column(SmallInteger)
     elapsed = Column(Interval, nullable=False)
 

--- a/tests/files/asus-eee-1000h.snapshot.bug1857.yaml
+++ b/tests/files/asus-eee-1000h.snapshot.bug1857.yaml
@@ -21,7 +21,7 @@
     ],
     "manufacturer": "ASUSTeK Computer INC."
   },
-  "uuid": "d1b70cb8-8929-4f36-99b7-fe052cec0abd",
+  "uuid": "d1b70cb8-8929-4f36-99b7-fe052cec0ab1",
   "components": [
   {
     "serialNumber": "00:24:8c:7f:cf:2d",

--- a/tests/files/asus-eee-1000h.snapshot.bug1857.yaml
+++ b/tests/files/asus-eee-1000h.snapshot.bug1857.yaml
@@ -1,0 +1,139 @@
+{
+  "type": "Snapshot",
+  "software": "Workbench",
+  "closed": false,
+  "device": {
+    "chassis": "Netbook",
+    "serialNumber": "94OAAQ021116",
+    "type": "Laptop",
+    "model": "1000H",
+    "actions": [
+    {
+      "elapsed": 19,
+      "rate": 19.3106,
+      "type": "BenchmarkRamSysbench"
+    },
+    {
+      "appearanceRange": "A",
+      "functionalityRange": "A",
+      "type": "VisualTest"
+    }
+    ],
+    "manufacturer": "ASUSTeK Computer INC."
+  },
+  "uuid": "d1b70cb8-8929-4f36-99b7-fe052cec0abd",
+  "components": [
+  {
+    "serialNumber": "00:24:8c:7f:cf:2d",
+    "speed": 100,
+    "type": "NetworkAdapter",
+    "wireless": false,
+    "model": "AR8121/AR8113/AR8114 Gigabit or Fast Ethernet",
+    "actions": [],
+    "manufacturer": "Qualcomm Atheros"
+  },
+  {
+    "serialNumber": null,
+    "type": "SoundCard",
+    "model": "NM10/ICH7 Family High Definition Audio Controller",
+    "actions": [],
+    "manufacturer": "Intel Corporation"
+  },
+  {
+    "serialNumber": "SN0001",
+    "type": "SoundCard",
+    "model": "CNF7129",
+    "actions": [],
+    "manufacturer": "Chicony Electronics Co., Ltd."
+  },
+  {
+    "size": 1024,
+    "serialNumber": null,
+    "format": "DIMM",
+    "type": "RamModule",
+    "interface": "SDRAM",
+    "model": null,
+    "actions": [],
+    "manufacturer": null
+  },
+  {
+    "serialNumber": null,
+    "threads": 2,
+    "speed": 1.0670000000000002,
+    "type": "Processor",
+    "address": 32,
+    "model": "Intel Atom CPU N270 @ 1.60GHz",
+    "actions": [
+    {
+      "elapsed": 172,
+      "rate": 171.6818,
+      "type": "BenchmarkProcessorSysbench"
+    },
+    {
+      "elapsed": 0,
+      "rate": 6383.8,
+      "type": "BenchmarkProcessor"
+    }
+    ],
+    "manufacturer": "Intel Corp."
+  },
+  {
+    "size": 80026.361856,
+    "interface": "ATA",
+    "model": "SAMSUNG HS082HB",
+    "manufacturer": null,
+    "actions": [
+      {
+        "elapsed": 25,
+        "writeSpeed": 14.9,
+        "readSpeed": 36.2,
+        "type": "BenchmarkDataStorage"
+      },
+      {
+        "severity": "Info",
+        "length": "Short",
+        "reallocatedSectorCount": 0,
+        "assessment": true,
+        "powerCycleCount": 2169,
+        "elapsed": 6,
+        "status": "Completed: read failure",
+        "offlineUncorrectable": 182042944,
+        "lifetime": 4634,
+        "currentPendingSectorCount": 473302660,
+        "type": "TestDataStorage"
+      }
+    ],
+    "variant": "0-05",
+    "serialNumber": "S17QJ16QA13332",
+    "type": "HardDrive"
+  },
+  {
+    "serialNumber": null,
+    "type": "GraphicCard",
+    "memory": 256.0,
+    "model": "Mobile 945GSE Express Integrated Graphics Controller",
+    "actions": [],
+    "manufacturer": "Intel Corporation"
+  },
+  {
+    "firewire": 0,
+    "usb": 5,
+    "pcmcia": 0,
+    "type": "Motherboard",
+    "serialNumber": "Eee0123456789",
+    "serial": 0,
+    "slots": 1,
+    "model": "1000H",
+    "actions": [
+    {
+      "accessRange": "A",
+      "type": "TestBios"
+    }
+    ],
+    "manufacturer": "ASUSTeK Computer INC."
+  }
+  ],
+  "version": "11.0a4",
+  "elapsed": 6,
+  "endTime": "2016-11-03T17:17:17.266543+00:00"
+}

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -764,7 +764,9 @@ def test_snapshot_bug_smallint_hdd(app: Devicehub, user: UserClient):
     snapshot_file = file('asus-eee-1000h.snapshot.bug1857')
     snapshot, _ = user.post(res=Snapshot, data=snapshot_file)
 
-    # assert '2001-01-01T00:00:00+00:00' in end_times
+    act = [act for act in snapshot['actions'] if act['type'] == 'TestDataStorage'][0]
+    assert act['currentPendingSectorCount'] == 473302660 
+    assert act['offlineUncorrectable'] == 182042944
 
     tmp_snapshots = app.config['TMP_SNAPSHOTS']
     shutil.rmtree(tmp_snapshots)

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -754,3 +754,17 @@ def test_snapshot_not_failed_end_time_bug(app: Devicehub, user: UserClient):
 
     tmp_snapshots = app.config['TMP_SNAPSHOTS']
     shutil.rmtree(tmp_snapshots)
+
+
+@pytest.mark.mvp
+def test_snapshot_bug_smallint_hdd(app: Devicehub, user: UserClient):
+    """ This test check if the end_time != 0001-01-01 00:00:00+00:00
+    and then we get a /devices, this create a crash
+    """
+    snapshot_file = file('asus-eee-1000h.snapshot.bug1857')
+    snapshot, _ = user.post(res=Snapshot, data=snapshot_file)
+
+    # assert '2001-01-01T00:00:00+00:00' in end_times
+
+    tmp_snapshots = app.config['TMP_SNAPSHOTS']
+    shutil.rmtree(tmp_snapshots)


### PR DESCRIPTION
https://github.com/eReuse/devicehub-teal/issues/67
Now the currentPendingSectorCount and offlineUncorrectable have an Integer field