### PR TITLE
Run black, flake8 & isort as pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 22.1.0
+    hooks:
+    - id: black
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.9.3
+    hooks:
+      - id: isort
+  - repo: https://github.com/PyCQA/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,7 @@ repos:
     rev: 4.0.1
     hooks:
       - id: flake8
+  - repo: https://github.com/conorfalvey/check_pdb_hook
+    rev: 0.0.9
+    hooks:
+    -   id: check_pdb_hook

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+; SHARED on https://pad.cas.cat/usody-devicehub-contributing
+
+# Contributing to devicehub
+
+## Writing code
+
+### Coding style
+
+#### Python style
+- Unless otherwise specified, follow [PEP 8](https://www.python.org/dev/peps/pep-0008). Use [flake8](https://pypi.org/project/flake8/) to check for problems in this area.
+- Use [isort](https://github.com/PyCQA/isort#readme) to automate import sorting.
+
+To automatize this work just configure `pre-commit` hooks in your development environment:
+```bash
+# on your virtual environment
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+#### HTML (templates)
+- Template file names should be all lowercase, using underscores instead of camelCase.
+
+  Do this: `device_detail.html`
+
+  Don't do this: `DeviceDetail.html`, `Device-detail.html`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+skip-string-normalization = true
+target-version = ['py38']
+
+[tool.isort]
+multi_line_output = 4

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,4 @@
+black
+isort
+flake8
+pre-commit

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,10 @@
+[flake8]
+count = True
+exclude =
+    migrations
+    resources   # exclude code that will be deprecated
+    tests   # exclude code that will be deprecated
+max-complexity = 10
+max-line-length = 120
+show-source = True
+statistics = True


### PR DESCRIPTION
Some configuration decissions that differs from default:
- black: [skip-string-normalization](https://github.com/psf/black/issues/957)
- isort: [multi_line_output](https://pycqa.github.io/isort/docs/configuration/multi_line_output_modes.html)

# How to test?
1. Follow [pre-commit installation instructions](https://pre-commit.com/#install)
2. Check-out this branch
3. Run hook. For example run isort on a single file
```bash
pre-commit run isort --files tests/test_action.py --show-diff-on-failure
```

## TODO
- [x] Create `CONTRIBUTING.md`including reference to `pre-commit` installation on development environment.