### PR TITLE
Feature/server side render ux improvements

### DIFF
--- a/ereuse_devicehub/cli.py
+++ b/ereuse_devicehub/cli.py
@@ -11,7 +11,7 @@ import sys
 sys.ps1 = '\001\033[92m\002>>> \001\033[0m\002'
 sys.ps2= '\001\033[94m\002... \001\033[0m\002'
 
-import os, readline, rlcompleter, atexit
+import os, readline, atexit
 history_file = os.path.join(os.environ['HOME'], '.python_history')
 try:
   readline.read_history_file(history_file)

--- a/ereuse_devicehub/cli.py
+++ b/ereuse_devicehub/cli.py
@@ -1,8 +1,8 @@
 import os
 
 import click.testing
-import ereuse_utils
 import flask.cli
+import ereuse_utils
 
 from ereuse_devicehub.config import DevicehubConfig
 from ereuse_devicehub.devicehub import Devicehub

--- a/ereuse_devicehub/devicehub.py
+++ b/ereuse_devicehub/devicehub.py
@@ -10,7 +10,6 @@ from ereuse_utils.session import DevicehubClient
 from flask import _app_ctx_stack, g
 from flask_login import LoginManager, current_user
 from flask_sqlalchemy import SQLAlchemy
-from flask_wtf.csrf import CSRFProtect
 from teal.db import SchemaSQLAlchemy
 from teal.teal import Teal
 

--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -113,7 +113,7 @@ class LotForm(FlaskForm):
         return self.id
 
     def remove(self):
-        if self.instance and not self.instance.devices:
+        if self.instance and not self.instance.trade:
             self.instance.delete()
             db.session.commit()
         return self.instance

--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -1,8 +1,6 @@
 import copy
 import json
 from json.decoder import JSONDecodeError
-from requests.exceptions import ConnectionError
-
 from boltons.urlutils import URL
 from flask import g, request
 from flask_wtf import FlaskForm
@@ -446,11 +444,7 @@ class TagUnnamedForm(FlaskForm):
 
     def save(self):
         num = self.amount.data
-        try:
-            tags_id, _ = g.tag_provider.post('/', {}, query=[('num', num)])
-        except ConnectionError:
-            pass
-            return []
+        tags_id, _ = g.tag_provider.post('/', {}, query=[('num', num)])
         tags = [Tag(id=tag_id, provider=g.inventory.tag_provider) for tag_id in tags_id]
         db.session.add_all(tags)
         db.session.commit()

--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -180,7 +180,7 @@ class UploadSnapshotForm(FlaskForm):
         db.session.commit()
         return response
 
-    def build(self, snapshot_json):
+    def build(self, snapshot_json):  # noqa: C901
         # this is a copy adaptated from ereuse_devicehub.resources.action.views.snapshot
         device = snapshot_json.pop('device')  # type: Computer
         components = None
@@ -294,7 +294,7 @@ class NewDeviceForm(FlaskForm):
         if not self.depth.data:
             self.depth.data = 0.1
 
-    def validate(self, extra_validators=None):
+    def validate(self, extra_validators=None):  # noqa: C901
         error = ["Not a correct value"]
         is_valid = super().validate(extra_validators)
 
@@ -489,7 +489,7 @@ class TagDeviceForm(FlaskForm):
         if self.device.data:
             try:
                 self.device.data = int(self.device.data.split(',')[-1])
-            except:
+            except:  # noqa: E722
                 self.device.data = None
 
         if self.device_id or self.device.data:

--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -464,9 +464,9 @@ class TagDeviceForm(FlaskForm):
         if self.delete:
             tags = Tag.query.filter(Tag.owner_id == g.user.id).filter_by(
                 device_id=self.device_id
-            )
+            ).order_by(Tag.id)
         else:
-            tags = Tag.query.filter(Tag.owner_id == g.user.id).filter_by(device_id=None)
+            tags = Tag.query.filter(Tag.owner_id == g.user.id).filter_by(device_id=None).order_by(Tag.id)
 
         self.tag.choices = [(tag.id, tag.id) for tag in tags]
 

--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -1,6 +1,7 @@
 import copy
 import json
 from json.decoder import JSONDecodeError
+from requests.exceptions import ConnectionError
 
 from boltons.urlutils import URL
 from ereuse_devicehub.db import db
@@ -411,7 +412,11 @@ class TagUnnamedForm(FlaskForm):
 
     def save(self):
         num = self.amount.data
-        tags_id, _ = g.tag_provider.post('/', {}, query=[('num', num)])
+        try:
+            tags_id, _ = g.tag_provider.post('/', {}, query=[('num', num)])
+        except ConnectionError:
+            pass
+            return []
         tags = [Tag(id=tag_id, provider=g.inventory.tag_provider) for tag_id in tags_id]
         db.session.add_all(tags)
         db.session.commit()

--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -62,7 +62,7 @@ class LotDeviceForm(FlaskForm):
 
         return bool(self._devices)
 
-    def save(self):
+    def save(self, commit=True):
         trade = self._lot.trade
         if trade:
             for dev in self._devices:
@@ -73,10 +73,16 @@ class LotDeviceForm(FlaskForm):
             self._lot.devices.update(self._devices)
             db.session.add(self._lot)
 
-    def remove(self):
+        if commit:
+            db.session.commit()
+
+    def remove(self, commit=True):
         if self._devices:
             self._lot.devices.difference_update(self._devices)
             db.session.add(self._lot)
+
+        if commit:
+            db.session.commit()
 
 
 class LotForm(FlaskForm):

--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -72,13 +72,11 @@ class LotDeviceForm(FlaskForm):
         if self._devices:
             self._lot.devices.update(self._devices)
             db.session.add(self._lot)
-            db.session.commit()
 
     def remove(self):
         if self._devices:
             self._lot.devices.difference_update(self._devices)
             db.session.add(self._lot)
-            db.session.commit()
 
 
 class LotForm(FlaskForm):

--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -32,6 +32,7 @@ from ereuse_devicehub.resources.documents.device_row import ActionRow, DeviceRow
 from ereuse_devicehub.resources.hash_reports import insert_hash
 from ereuse_devicehub.resources.lot.models import Lot
 from ereuse_devicehub.resources.tag.model import Tag
+from ereuse_devicehub.db import db
 
 # TODO(@slamora): rename base 'inventory.devices' --> 'inventory'
 devices = Blueprint('inventory.devices', __name__, url_prefix='/inventory')
@@ -142,6 +143,7 @@ class LotDeviceAddView(View):
             messages.success(
                 'Add devices to lot "{}" successfully!'.format(form._lot.name)
             )
+            db.session.commit()
         else:
             messages.error('Error adding devices to lot!')
 
@@ -161,6 +163,7 @@ class LotDeviceDeleteView(View):
             messages.success(
                 'Remove devices from lot "{}" successfully!'.format(form._lot.name)
             )
+            db.session.commit()
         else:
             messages.error('Error removing devices from lot!')
 

--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -211,6 +211,13 @@ class LotDeleteView(View):
 
     def dispatch_request(self, id):
         form = LotForm(id=id)
+        if form.instance.devices:
+            msg = ("Sorry, the lot cannot be deleted because it still "
+                "has associated devices. Only empty lots can be deleted")
+            messages.error(msg)
+            next_url = url_for('inventory.devices.lotdevicelist', lot_id=id)
+            return flask.redirect(next_url)
+
         form.remove()
         next_url = url_for('inventory.devices.devicelist')
         return flask.redirect(next_url)

--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -47,7 +47,7 @@ class DeviceListMix(View):
         tags = (
             Tag.query.filter(Tag.owner_id == current_user.id)
             .filter(Tag.device_id.is_(None))
-            .order_by(Tag.created.desc())
+            .order_by(Tag.id.asc())
         )
 
         if lot_id:
@@ -236,7 +236,7 @@ class TagListView(View):
 
     def dispatch_request(self):
         lots = Lot.query.filter(Lot.owner_id == current_user.id)
-        tags = Tag.query.filter(Tag.owner_id == current_user.id)
+        tags = Tag.query.filter(Tag.owner_id == current_user.id).order_by(Tag.id)
         context = {
             'lots': lots,
             'tags': tags,

--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -256,7 +256,10 @@ class TagAddUnnamedView(View):
         context = {'page_title': 'New Unnamed Tag', 'lots': lots}
         form = TagUnnamedForm()
         if form.validate_on_submit():
-            form.save()
+            tags = form.save()
+            if not tags:
+                msg = 'Sorry, the communication with the tag server is not possible now!'
+                messages.error(msg)
             next_url = url_for('inventory.devices.taglist')
             return flask.redirect(next_url)
 

--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -211,9 +211,8 @@ class LotDeleteView(View):
 
     def dispatch_request(self, id):
         form = LotForm(id=id)
-        if form.instance.devices:
-            msg = ("Sorry, the lot cannot be deleted because it still "
-                "has associated devices. Only empty lots can be deleted")
+        if form.instance.trade:
+            msg = "Sorry, the lot cannot be deleted because have a trade action "
             messages.error(msg)
             next_url = url_for('inventory.devices.lotdevicelist', lot_id=id)
             return flask.redirect(next_url)

--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -139,7 +139,7 @@ class LotDeviceAddView(View):
     def dispatch_request(self):
         form = LotDeviceForm()
         if form.validate_on_submit():
-            form.save()
+            form.save(commit=False)
             messages.success(
                 'Add devices to lot "{}" successfully!'.format(form._lot.name)
             )
@@ -159,7 +159,7 @@ class LotDeviceDeleteView(View):
     def dispatch_request(self):
         form = LotDeviceForm()
         if form.validate_on_submit():
-            form.remove()
+            form.remove(commit=False)
             messages.success(
                 'Remove devices from lot "{}" successfully!'.format(form._lot.name)
             )

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -474,6 +474,13 @@ class Device(Thing):
                                         key=attrgetter('type'))  # last test of each type
         return self._warning_actions(current_tests)
 
+    @property
+    def verbose_name(self):
+        type = self.type or ''
+        manufacturer = self.manufacturer or ''
+        model = self.model or ''
+        return f'{type} {manufacturer} {model}'
+
     @declared_attr
     def __mapper_args__(cls):
         """Defines inheritance.

--- a/ereuse_devicehub/static/js/main_inventory.js
+++ b/ereuse_devicehub/static/js/main_inventory.js
@@ -62,15 +62,26 @@ function deviceSelect() {
 function removeTag() {
     var devices = $(".deviceSelect").filter(':checked');
     var devices_id = $.map(devices, function(x) { return $(x).attr('data')});
-    if (devices_id.length > 0) {
+    if (devices_id.length == 1) {
         var url = "/inventory/tag/devices/"+devices_id[0]+"/del/";
         window.location.href = url;
+    } else {
+        $("#unlinkTagAlertModal").click();
     }
 }
 
 function addTag() {
-    deviceSelect();
-    $("#addingTagModal").click();
+    var devices = $(".deviceSelect").filter(':checked');
+    var devices_id = $.map(devices, function(x) { return $(x).attr('data')});
+    if (devices_id.length == 1) {
+        $("#addingTagModal .pol").hide();
+        $("#addingTagModal .btn-primary").show();
+    } else {
+        $("#addingTagModal .pol").show();
+        $("#addingTagModal .btn-primary").hide();
+    }
+
+    $("#addTagAlertModal").click();
 }
 
 function newTrade(action) {

--- a/ereuse_devicehub/static/js/main_inventory.js
+++ b/ereuse_devicehub/static/js/main_inventory.js
@@ -59,6 +59,16 @@ function deviceSelect() {
     }
 }
 
+function removeLot() {
+    var devices = $(".deviceSelect");
+    if (devices.length > 0) {
+        $("#btnRemoveLots .text-danger").show();
+    } else {
+        $("#btnRemoveLots .text-danger").hide();
+    }
+    $("#activeRemoveLotModal").click();
+}
+
 function removeTag() {
     var devices = $(".deviceSelect").filter(':checked');
     var devices_id = $.map(devices, function(x) { return $(x).attr('data')});

--- a/ereuse_devicehub/static/js/print.pdf.js
+++ b/ereuse_devicehub/static/js/print.pdf.js
@@ -65,5 +65,5 @@ function printpdf() {
     min_tag_side = (Math.min(height, width)/2) + border;
     pdf.addImage(imgData, 'PNG', border, border, img_side, img_side);
     pdf.text(tag, max_tag_side, min_tag_side);
-    pdf.save('Tags.pdf');
+    pdf.save('Tag_'+tag+'.pdf');
 }

--- a/ereuse_devicehub/templates/ereuse_devicehub/base.html
+++ b/ereuse_devicehub/templates/ereuse_devicehub/base.html
@@ -19,10 +19,12 @@
 
   <!-- JS Files -->
   <script src="{{ url_for('static', filename='js/jquery-3.6.0.min.js') }}"></script>
+  <script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest"></script>
 
   <!-- Vendor CSS Files -->
   <link href="{{ url_for('static', filename='vendor/bootstrap/css/bootstrap.min.css') }}" rel="stylesheet">
   <link href="{{ url_for('static', filename='vendor/bootstrap-icons/bootstrap-icons.css') }}" rel="stylesheet">
+  <link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
 
 
   <!-- Template Main CSS File -->

--- a/ereuse_devicehub/templates/ereuse_devicehub/base.html
+++ b/ereuse_devicehub/templates/ereuse_devicehub/base.html
@@ -17,6 +17,9 @@
   <link href="https://fonts.gstatic.com" rel="preconnect">
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,300i,400,400i,600,600i,700,700i|Nunito:300,300i,400,400i,600,600i,700,700i|Poppins:300,300i,400,400i,500,500i,600,600i,700,700i" rel="stylesheet">
 
+  <!-- JS Files -->
+  <script src="{{ url_for('static', filename='js/jquery-3.6.0.min.js') }}"></script>
+
   <!-- Vendor CSS Files -->
   <link href="{{ url_for('static', filename='vendor/bootstrap/css/bootstrap.min.css') }}" rel="stylesheet">
   <link href="{{ url_for('static', filename='vendor/bootstrap-icons/bootstrap-icons.css') }}" rel="stylesheet">

--- a/ereuse_devicehub/templates/inventory/addDevicestag.html
+++ b/ereuse_devicehub/templates/inventory/addDevicestag.html
@@ -18,7 +18,7 @@
           </select>
           <input class="devicesList" type="hidden" name="device" />
           <p class="text-danger pol">
-              You need select first some device for adding this in a tag
+              You need select first one device and only one for add this in a tag
           </p>
         </div>
 

--- a/ereuse_devicehub/templates/inventory/alert_unlink_tag_error.html
+++ b/ereuse_devicehub/templates/inventory/alert_unlink_tag_error.html
@@ -1,0 +1,21 @@
+<div class="modal fade" id="unlinkTagErrorModal" tabindex="-1" style="display: none;" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Error Unlink Tag</h5>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+
+        <div class="modal-body">
+          <p class="text-danger pol">
+              You need select first one device and only one for Unlink one Tag
+          </p>
+        </div>
+
+        <div class="modal-footer">
+          <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+        </div>
+
+    </div>
+  </div>
+</div>

--- a/ereuse_devicehub/templates/inventory/device_create.html
+++ b/ereuse_devicehub/templates/inventory/device_create.html
@@ -385,6 +385,5 @@
     </div>
   </div>
 </section>
-<script src="{{ url_for('static', filename='js/jquery-3.6.0.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/create_device.js') }}"></script>
 {% endblock main %}

--- a/ereuse_devicehub/templates/inventory/device_create.html
+++ b/ereuse_devicehub/templates/inventory/device_create.html
@@ -31,7 +31,7 @@
                 <form method="post" class="row g-3 needs-validation" novalidate>
                   {{ form.csrf_token }}
 
-                  <div class="col-12">
+                  <div>
                     <div class="form-group has-validation mb-2">
                       <label for="name" class="form-label">Type *</label>
                       <select id="type" class="form-control" name="type" required="">
@@ -369,7 +369,7 @@
 
                   </div>
 
-                  <div class="col-12">
+                  <div>
                     <a href="{{ url_for('inventory.devices.devicelist') }}" class="btn btn-danger">Cancel</a>
                     <button class="btn btn-primary" type="submit">Save</button>
                   </div>

--- a/ereuse_devicehub/templates/inventory/device_detail.html
+++ b/ereuse_devicehub/templates/inventory/device_detail.html
@@ -1,6 +1,5 @@
 {% extends "ereuse_devicehub/base_site.html" %}
 {% block main %}
-<link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
 
 <div class="pagetitle">
   <h1>Inventory</h1>

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -246,7 +246,7 @@
                       </td>
                       <td>
                         <a href="{{ url_for('inventory.devices.device_details', id=dev.devicehub_id)}}">
-                          {{ dev.type }} {{ dev.manufacturer }} {{ dev.model }}
+                          {{ dev.type }} {{ dev.manufacturer|d('', true) }} {{ dev.model|d('', true) }}
                         </a>
                       </td>
                       <td>

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -39,7 +39,7 @@
               </div>
               <div class="col">
                   {% if lot and lot.is_temporary and not lot.devices %}
-                    <a href="javascript:void()" class="" data-bs-toggle="modal" data-bs-target="#btnRemoveLots">
+                    <a href="javascript:void()" data-bs-toggle="modal" data-bs-target="#btnRemoveLots">
                       <i class="bi bi-trash"></i>
                       Remove Lot
                     </a>
@@ -47,18 +47,18 @@
               </div>
               <div class="col">
                   {% if lot and lot.is_temporary %}
-                  <a href="javascript:void()" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addingLotModal">
-                    <i class="bi bi-plus"></i>
-                    Add selected Devices to a lot
-                  </a>
+                    <a href="javascript:newTrade('user_from')">
+                      <i class="bi bi-plus"></i>
+                      Add supplier
+                    </a>
                   {% endif %}
               </div>
               <div class="col">
                   {% if lot and lot.is_temporary %}
-                  <a href="javascript:void()" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#removeLotModal">
-                    <i class="bi bi-x"></i>
-                    Remove selected devices from a lot
-                  </a>
+                    <a href="javascript:newTrade('user_to')">
+                      <i class="bi bi-plus"></i>
+                      Add receiver
+                    </a>
                   {% endif %}
               </div>
             </div>
@@ -92,16 +92,6 @@
                 </button>
                 <span class="d-none" id="activeTradeModal" data-bs-toggle="modal" data-bs-target="#tradeLotModal"></span>
                 <ul class="dropdown-menu" aria-labelledby="btnLots">
-                {% if lot and lot.is_temporary and not lot.devices %}
-                  <li>
-                    <a href="javascript:newAction('Use')" class="dropdown-item"
-                        data-bs-toggle="modal" data-bs-target="#btnRemoveLots">
-                      <i class="bi bi-trash"></i>
-                      Remove Lot
-                      <span class="caret"></span>
-                    </a>
-                  </li>
-                {% endif %}
                   <li>
                     <a href="javascript:void()" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addingLotModal">
                       <i class="bi bi-plus"></i>
@@ -114,29 +104,6 @@
                       Remove selected devices from a lot
                     </a>
                   </li>
-                  {% if lot.is_temporary %}
-                  <li>
-                    <a href="javascript:newTrade('user_from')" class="dropdown-item">
-                      <i class="bi bi-plus"></i>
-                      Add supplier
-                    </a>
-                  </li>
-                  <li>
-                    <a href="javascript:newTrade('user_to')" class="dropdown-item">
-                      <i class="bi bi-plus"></i>
-                      Add receiver
-                    </a>
-                  </li>
-                  {% endif %}
-                  {% if lot and not lot.is_temporary %}
-                  <li>
-                    <a href="{{ url_for('inventory.devices.trade_document_add', lot_id=lot.id)}}" class="dropdown-item">
-                      <i class="bi bi-plus"></i>
-                      Add new document
-                      <span class="caret"></span>
-                    </a>
-                  </li>
-                  {% endif %}
                 </ul>
               </div>
               <div class="btn-group dropdown ml-1" uib-dropdown="">
@@ -283,7 +250,7 @@
 
               <div class="btn-group dropdown ml-1" uib-dropdown="">
                 <button id="btnSnapshot" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
-                    <i class="bi bi-tag"></i>
+                    <i class="bi bi-laptop"></i>
                     New Device
                 </button>
                 <ul class="dropdown-menu" aria-labelledby="btnSnapshot">
@@ -301,6 +268,24 @@
                   </li>
                 </ul>
               </div>
+
+              {% if lot and not lot.is_temporary %}
+              <div class="btn-group dropdown ml-1" uib-dropdown="">
+                <button id="btnSnapshot" type="button" class="btn btn-primary dropdown-toggle" data-bs-toggle="dropdown" aria-expanded="false">
+                    <i class="bi bi-book"></i>
+                    Documents
+                </button>
+                <ul class="dropdown-menu" aria-labelledby="btnSnapshot">
+                  <li>
+                    <a href="{{ url_for('inventory.devices.trade_document_add', lot_id=lot.id)}}" class="dropdown-item">
+                      <i class="bi bi-plus"></i>
+                      Add new document
+                      <span class="caret"></span>
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              {% endif %}
 
               <div class="tab-content pt-2">
 

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -33,8 +33,34 @@
         <div class="card-body pt-3">
           <!-- Bordered Tabs -->
 
-            <div class="col-12">
-                <h3><a href="{{ url_for('inventory.devices.lot_edit', id=lot.id) }}">{{ lot.name }}</a></h3>
+            <div class="row">
+              <div class="col-6">
+                  <h3><a href="{{ url_for('inventory.devices.lot_edit', id=lot.id) }}">{{ lot.name }}</a></h3>
+              </div>
+              <div class="col">
+                  {% if lot and lot.is_temporary and not lot.devices %}
+                    <a href="javascript:void()" class="" data-bs-toggle="modal" data-bs-target="#btnRemoveLots">
+                      <i class="bi bi-trash"></i>
+                      Remove Lot
+                    </a>
+                  {% endif %}
+              </div>
+              <div class="col">
+                  {% if lot and lot.is_temporary %}
+                  <a href="javascript:void()" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addingLotModal">
+                    <i class="bi bi-plus"></i>
+                    Add selected Devices to a lot
+                  </a>
+                  {% endif %}
+              </div>
+              <div class="col">
+                  {% if lot and lot.is_temporary %}
+                  <a href="javascript:void()" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#removeLotModal">
+                    <i class="bi bi-x"></i>
+                    Remove selected devices from a lot
+                  </a>
+                  {% endif %}
+              </div>
             </div>
         </div>
       </div>

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -1,6 +1,5 @@
 {% extends "ereuse_devicehub/base_site.html" %}
 {% block main %}
-<link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
 
 <div class="pagetitle">
   <h1>Inventory</h1>
@@ -386,14 +385,9 @@
 {% include "inventory/trade.html" %}
 {% include "inventory/alert_export_error.html" %}
 
-<!-- CDN -->
-<script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest"></script>
 <!-- Custom Code -->
 <script>
   const table = new simpleDatatables.DataTable("table")
-</script>
-<script>
-
 </script>
 <script src="{{ url_for('static', filename='js/main_inventory.js') }}"></script>
 {% endblock main %}

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -38,7 +38,8 @@
               </div>
               <div class="col">
                   {% if lot and lot.is_temporary %}
-                    <a href="javascript:void()" data-bs-toggle="modal" data-bs-target="#btnRemoveLots">
+                    <span class="d-none" id="activeRemoveLotModal" data-bs-toggle="modal" data-bs-target="#btnRemoveLots"></span>
+                    <a href="javascript:removeLot()">
                       <i class="bi bi-trash"></i>
                       Remove Lot
                     </a>

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -42,10 +42,10 @@
                   <i class="bi bi-trash"></i> Remove Lot
                 </a>
                 <a class="me-2" href="javascript:newTrade('user_from')">
-                  <i class="bi bi-plus"></i> Add supplier
+                  <i class="bi bi-arrow-down-right"></i> Add supplier
                 </a>
                 <a href="javascript:newTrade('user_to')">
-                  <i class="bi bi-plus"></i> Add receiver
+                  <i class="bi bi-arrow-up-right"></i> Add receiver
                 </a>
               {% endif %}
             </div>

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -37,7 +37,7 @@
                   <h3><a href="{{ url_for('inventory.devices.lot_edit', id=lot.id) }}">{{ lot.name }}</a></h3>
               </div>
               <div class="col">
-                  {% if lot and lot.is_temporary and not lot.devices %}
+                  {% if lot and lot.is_temporary %}
                     <a href="javascript:void()" data-bs-toggle="modal" data-bs-target="#btnRemoveLots">
                       <i class="bi bi-trash"></i>
                       Remove Lot

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -231,17 +231,19 @@
                     <i class="bi bi-tag"></i>
                     Tags
                 </button>
+                <span class="d-none" id="unlinkTagAlertModal" data-bs-toggle="modal" data-bs-target="#unlinkTagErrorModal"></span>
+                <span class="d-none" id="addTagAlertModal" data-bs-toggle="modal" data-bs-target="#addingTagModal"></span>
                 <ul class="dropdown-menu" aria-labelledby="btnTags">
                   <li>
-                    <a href="javascript:addTag()" class="dropdown-item" data-bs-toggle="modal" data-bs-target="#addingTagModal">
+                    <a href="javascript:addTag()" class="dropdown-item">
                       <i class="bi bi-plus"></i>
-                      Add Tag to selected Devices
+                      Add Tag to selected Device
                     </a>
                   </li>
                   <li>
                     <a href="javascript:removeTag()" class="dropdown-item">
                       <i class="bi bi-x"></i>
-                      Remove Tag from selected Devices
+                      Remove Tag from selected Device
                     </a>
                   </li>
                 </ul>
@@ -384,6 +386,7 @@
 {% include "inventory/data_wipe.html" %}
 {% include "inventory/trade.html" %}
 {% include "inventory/alert_export_error.html" %}
+{% include "inventory/alert_unlink_tag_error.html" %}
 
 <!-- Custom Code -->
 <script>

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -395,6 +395,5 @@
 <script>
 
 </script>
-<script src="{{ url_for('static', filename='js/jquery-3.6.0.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/main_inventory.js') }}"></script>
 {% endblock main %}

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -316,7 +316,7 @@
                       </td>
                       <td>
                         <a href="{{ url_for('inventory.devices.device_details', id=dev.devicehub_id)}}">
-                          {{ dev.type }} {{ dev.manufacturer|d('', true) }} {{ dev.model|d('', true) }}
+                          {{ dev.verbose_name }}
                         </a>
                       </td>
                       <td>

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -32,36 +32,24 @@
         <div class="card-body pt-3">
           <!-- Bordered Tabs -->
 
-            <div class="row">
-              <div class="col-6">
-                  <h3><a href="{{ url_for('inventory.devices.lot_edit', id=lot.id) }}">{{ lot.name }}</a></h3>
-              </div>
-              <div class="col">
-                  {% if lot and lot.is_temporary %}
-                    <span class="d-none" id="activeRemoveLotModal" data-bs-toggle="modal" data-bs-target="#btnRemoveLots"></span>
-                    <a href="javascript:removeLot()">
-                      <i class="bi bi-trash"></i>
-                      Remove Lot
-                    </a>
-                  {% endif %}
-              </div>
-              <div class="col">
-                  {% if lot and lot.is_temporary %}
-                    <a href="javascript:newTrade('user_from')">
-                      <i class="bi bi-plus"></i>
-                      Add supplier
-                    </a>
-                  {% endif %}
-              </div>
-              <div class="col">
-                  {% if lot and lot.is_temporary %}
-                    <a href="javascript:newTrade('user_to')">
-                      <i class="bi bi-plus"></i>
-                      Add receiver
-                    </a>
-                  {% endif %}
-              </div>
+          <div class="d-flex align-items-center justify-content-between">
+            <h3><a href="{{ url_for('inventory.devices.lot_edit', id=lot.id) }}">{{ lot.name }}</a></h3>
+
+            <div><!-- lot actions -->
+              {% if lot.is_temporary %}
+                <span class="d-none" id="activeRemoveLotModal" data-bs-toggle="modal" data-bs-target="#btnRemoveLots"></span>
+                <a class="me-2" href="javascript:removeLot()">
+                  <i class="bi bi-trash"></i> Remove Lot
+                </a>
+                <a class="me-2" href="javascript:newTrade('user_from')">
+                  <i class="bi bi-plus"></i> Add supplier
+                </a>
+                <a href="javascript:newTrade('user_to')">
+                  <i class="bi bi-plus"></i> Add receiver
+                </a>
+              {% endif %}
             </div>
+          </div>
         </div>
       </div>
       {% endif %}

--- a/ereuse_devicehub/templates/inventory/lot.html
+++ b/ereuse_devicehub/templates/inventory/lot.html
@@ -43,7 +43,11 @@
                   </div>
 
                   <div class="col-12">
-                    <a href="{{ url_for('inventory.devices.devicelist') }}" class="btn btn-danger">Cancel</a>
+                    {% if form.id %}
+                      <a href="{{ url_for('inventory.devices.lotdevicelist', lot_id=form.id) }}" class="btn btn-danger">Cancel</a>
+                    {% else %}
+                      <a href="{{ url_for('inventory.devices.devicelist') }}" class="btn btn-danger">Cancel</a>
+                    {% endif %}
                     <button class="btn btn-primary" type="submit">Save</button>
                   </div>
                 </form>

--- a/ereuse_devicehub/templates/inventory/lot.html
+++ b/ereuse_devicehub/templates/inventory/lot.html
@@ -34,7 +34,7 @@
                 <form method="post" class="row g-3 needs-validation" novalidate>
                   {{ form.csrf_token }}
 
-                  <div class="col-12">
+                  <div>
                     <label for="name" class="form-label">Name</label>
                     <div class="input-group has-validation">
                       <input type="text" name="name" class="form-control" required value="{{ form.name.data|default('', true) }}">
@@ -42,7 +42,7 @@
                     </div>
                   </div>
 
-                  <div class="col-12">
+                  <div>
                     {% if form.id %}
                       <a href="{{ url_for('inventory.devices.lotdevicelist', lot_id=form.id) }}" class="btn btn-danger">Cancel</a>
                     {% else %}

--- a/ereuse_devicehub/templates/inventory/removelot.html
+++ b/ereuse_devicehub/templates/inventory/removelot.html
@@ -9,12 +9,15 @@
 
         <div class="modal-body">
             Are you sure that you want to remove lot <strong>{{ lot.name }}</strong>?
+            <p class="text-danger">
+               There are devices in this lot, are you sure you want to delete it?
+            </p>
         </div>
 
         <div class="modal-footer">
           <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
           <a href="{{ url_for('inventory.devices.lot_del', id=lot.id)}}" type="button" class="btn btn-primary">
-            Save changes
+            Confirm
           </a>
         </div>
 

--- a/ereuse_devicehub/templates/inventory/tag_create.html
+++ b/ereuse_devicehub/templates/inventory/tag_create.html
@@ -33,7 +33,7 @@
                 <form method="post" class="row g-3 needs-validation" novalidate>
                   {{ form.csrf_token }}
 
-                  <div class="col-12">
+                  <div>
                     <label for="code" class="form-label">code</label>
                     <div class="input-group has-validation">
                       <input type="text" name="code" class="form-control" required value="{{ form.code.data|default('', true) }}">
@@ -48,7 +48,7 @@
                     {% endif %}
                   </div>
 
-                  <div class="col-12">
+                  <div>
                     <a href="{{ url_for('inventory.devices.taglist') }}" class="btn btn-danger">Cancel</a>
                     <button class="btn btn-primary" type="submit">Save</button>
                   </div>

--- a/ereuse_devicehub/templates/inventory/tag_create_unnamed.html
+++ b/ereuse_devicehub/templates/inventory/tag_create_unnamed.html
@@ -33,7 +33,7 @@
                 <form method="post" class="row g-3 needs-validation" novalidate>
                   {{ form.csrf_token }}
 
-                  <div class="col-12">
+                  <div>
                     <label for="code" class="form-label">Amount</label>
                     <div class="input-group has-validation">
                       {{ form.amount(class_="form-control") }}
@@ -48,7 +48,7 @@
                     {% endif %}
                   </div>
 
-                  <div class="col-12">
+                  <div>
                     <a href="{{ url_for('inventory.devices.taglist') }}" class="btn btn-danger">Cancel</a>
                     <button class="btn btn-primary" type="submit">Save</button>
                   </div>

--- a/ereuse_devicehub/templates/inventory/tag_detail.html
+++ b/ereuse_devicehub/templates/inventory/tag_detail.html
@@ -35,7 +35,7 @@
                 <div class="col-lg-9 col-md-8">
                     {% if tag.device %}
                       <a href="{{url_for('inventory.devices.device_details', id=tag.device.devicehub_id)}}">
-                          {{ tag.device.manufacturer }} {{ tag.device.model }}
+                          {{ tag.device.type }} {{ tag.device.manufacturer|d('', true) }} {{ tag.device.model|d('', true) }}
                       </a>
                     {% endif %}
                 </div>

--- a/ereuse_devicehub/templates/inventory/tag_detail.html
+++ b/ereuse_devicehub/templates/inventory/tag_detail.html
@@ -1,6 +1,5 @@
 {% extends "ereuse_devicehub/base_site.html" %}
 {% block main %}
-<link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
 
 <div class="pagetitle">
   <h1>Inventory</h1>

--- a/ereuse_devicehub/templates/inventory/tag_detail.html
+++ b/ereuse_devicehub/templates/inventory/tag_detail.html
@@ -106,7 +106,6 @@
     </div>
   </div>
 </section>
-<script src="{{ url_for('static', filename='js/jquery-3.6.0.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/qrcode.js') }}"></script>
 <script src="{{ url_for('static', filename='js/jspdf.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/print.pdf.js') }}"></script>

--- a/ereuse_devicehub/templates/inventory/tag_detail.html
+++ b/ereuse_devicehub/templates/inventory/tag_detail.html
@@ -34,7 +34,7 @@
                 <div class="col-lg-9 col-md-8">
                     {% if tag.device %}
                       <a href="{{url_for('inventory.devices.device_details', id=tag.device.devicehub_id)}}">
-                          {{ tag.device.type }} {{ tag.device.manufacturer|d('', true) }} {{ tag.device.model|d('', true) }}
+                          {{ tag.device.verbose_name }}
                       </a>
                     {% endif %}
                 </div>

--- a/ereuse_devicehub/templates/inventory/tag_list.html
+++ b/ereuse_devicehub/templates/inventory/tag_list.html
@@ -59,7 +59,7 @@
                       <td>
                         {% if tag.device %}
                         <a href={{ url_for('inventory.devices.device_details', id=tag.device.devicehub_id)}}>
-                          {{ tag.device.type }} {{ tag.device.manufacturer }} {{ tag.device.model }}
+                          {{ tag.device.type }} {{ tag.device.manufacturer|d('', true) }} {{ tag.device.model|d('', true) }}
                         </a>
                         {% endif %}
                       </td>

--- a/ereuse_devicehub/templates/inventory/tag_list.html
+++ b/ereuse_devicehub/templates/inventory/tag_list.html
@@ -86,5 +86,4 @@
 <script>
 
 </script>
-<script src="{{ url_for('static', filename='js/jquery-3.6.0.min.js') }}"></script>
 {% endblock main %}

--- a/ereuse_devicehub/templates/inventory/tag_list.html
+++ b/ereuse_devicehub/templates/inventory/tag_list.html
@@ -58,7 +58,7 @@
                       <td>
                         {% if tag.device %}
                         <a href={{ url_for('inventory.devices.device_details', id=tag.device.devicehub_id)}}>
-                          {{ tag.device.type }} {{ tag.device.manufacturer|d('', true) }} {{ tag.device.model|d('', true) }}
+                          {{ tag.device.verbose_name }}
                         </a>
                         {% endif %}
                       </td>

--- a/ereuse_devicehub/templates/inventory/tag_list.html
+++ b/ereuse_devicehub/templates/inventory/tag_list.html
@@ -1,6 +1,5 @@
 {% extends "ereuse_devicehub/base_site.html" %}
 {% block main %}
-<link href="https://cdn.jsdelivr.net/npm/simple-datatables@latest/dist/style.css" rel="stylesheet" type="text/css">
 
 <div class="pagetitle">
   <h1>Inventory</h1>
@@ -77,13 +76,8 @@
   </div>
 </section>
 
-<!-- CDN -->
-<script src="https://cdn.jsdelivr.net/npm/simple-datatables@latest"></script>
 <!-- Custom Code -->
 <script>
   const table = new simpleDatatables.DataTable("table")
-</script>
-<script>
-
 </script>
 {% endblock main %}

--- a/ereuse_devicehub/templates/inventory/tag_unlink_device.html
+++ b/ereuse_devicehub/templates/inventory/tag_unlink_device.html
@@ -32,7 +32,7 @@
                 <form method="post" class="row g-3 needs-validation" novalidate>
                   {{ form.csrf_token }}
 
-                  <div class="col-12">
+                  <div>
                     <label for="tag" class="form-label">Tag</label>
                     <div class="input-group has-validation">
                       {{ form.tag(class_="form-control") }}
@@ -48,7 +48,7 @@
                   </div>
                   <input class="devicesList" type="hidden" name="device" />
 
-                  <div class="col-12">
+                  <div>
                     <a href="{{ referrer }}" class="btn btn-danger">Cancel</a>
                     <button class="btn btn-primary" type="submit">Unlink</button>
                   </div>

--- a/ereuse_devicehub/templates/inventory/tag_unlink_device.html
+++ b/ereuse_devicehub/templates/inventory/tag_unlink_device.html
@@ -50,7 +50,7 @@
 
                   <div class="col-12">
                     <a href="{{ referrer }}" class="btn btn-danger">Cancel</a>
-                    <button class="btn btn-primary" type="submit">Save</button>
+                    <button class="btn btn-primary" type="submit">Unlink</button>
                   </div>
                 </form>
 

--- a/ereuse_devicehub/templates/inventory/trade_document.html
+++ b/ereuse_devicehub/templates/inventory/trade_document.html
@@ -39,15 +39,15 @@
                 {{ field.label(class_="form-label") }}
                 {{ field }}
                 <small class="text-muted">{{ field.description }}</small>
-              {% endif %}
-              {% if field.errors %}
+                {% if field.errors %}
                 <p class="text-danger">
                   {% for error in field.errors %}
                     {{ error }}<br/>
                   {% endfor %}
                 </p>
-              {% endif %}
+                {% endif %}
               </div>
+              {% endif %}
             {% endfor %}
 
             <div class="col-12">

--- a/ereuse_devicehub/templates/inventory/trade_document.html
+++ b/ereuse_devicehub/templates/inventory/trade_document.html
@@ -35,7 +35,7 @@
             {{ form.csrf_token }}
             {% for field in form %}
               {% if field != form.csrf_token %}
-              <div class="col-12">
+              <div>
                 {{ field.label(class_="form-label") }}
                 {{ field }}
                 <small class="text-muted">{{ field.description }}</small>
@@ -50,7 +50,7 @@
               {% endif %}
             {% endfor %}
 
-            <div class="col-12">
+            <div>
               <a href="{{ url_for('inventory.devices.lotdevicelist', lot_id=form._lot.id) }}" class="btn btn-danger">Cancel</a>
               <button class="btn btn-primary" type="submit">Save</button>
             </div>

--- a/ereuse_devicehub/templates/inventory/upload_snapshot.html
+++ b/ereuse_devicehub/templates/inventory/upload_snapshot.html
@@ -33,7 +33,7 @@
                 <form method="post" enctype="multipart/form-data" class="row g-3 needs-validation" novalidate>
                   {{ form.csrf_token }}
 
-                  <div class="col-12">
+                  <div>
                     <label for="name" class="form-label">Select a Snapshot file</label>
                     <div class="input-group has-validation">
                       {{ form.snapshot }}
@@ -54,7 +54,7 @@
                     {% endif %}
                   </div>
 
-                  <div class="col-12">
+                  <div>
                     <a href="{{ url_for('inventory.devices.devicelist') }}" class="btn btn-danger">Cancel</a>
                     <button class="btn btn-primary" type="submit">Send</button>
                   </div>


### PR DESCRIPTION
Note: numbers of taiga
[#2734](https://tree.taiga.io/project/usody/us/2734) UX improvements on Devicehub server render
* #2629 Drop stamps navbar link
* #2739 tag-detail: "None none" shown as device string if there is no info about Manufacter and Model.
* #2740 tag-print: Include tag code on generated filename: now is always "Tags.pdf"
* #2741 tag-unnamed-add: Handle connection error when trying to connect to `g.tag_provider`. Provide a error message instead of raising 500 error
* #2835 Reorganize buttons of lot actions.
* #2736 Move JS & CSS to base_site.html
* #2735 tag-list: Default tags order_by: code