### PR TITLE
fix change #2825, tags only for Computers

### DIFF
--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -1206,8 +1206,9 @@ def create_code_tag(mapper, connection, device):
     this tag is the same of devicehub_id.
     """
     from ereuse_devicehub.resources.tag.model import Tag
-    tag = Tag(device_id=device.id, id=device.devicehub_id)
-    db.session.add(tag)
+    if isinstance(device, Computer):
+        tag = Tag(device_id=device.id, id=device.devicehub_id)
+        db.session.add(tag)
 
 
 event.listen(Device, 'after_insert', create_code_tag, propagate=True)


### PR DESCRIPTION
[2825](https://tree.taiga.io/project/usody/us/2825) Only create automatic named tag for "parent" device on snapshot
Don't build tags for components.