### PR TITLE
FIX: clickable lots selector not working when click in text

### DIFF
--- a/ereuse_devicehub/static/js/main_inventory.js
+++ b/ereuse_devicehub/static/js/main_inventory.js
@@ -200,8 +200,9 @@ async function processSelectedDevices() {
          */
         manage(event, lotID, deviceListID) {
             event.preventDefault();
-            const indeterminate = event.srcElement.indeterminate;
-            const checked = !event.srcElement.checked;
+            const srcElement = event.srcElement.parentElement.children[0]
+            const indeterminate = srcElement.indeterminate;
+            const checked = !srcElement.checked;
 
             var found = this.list.filter(list => list.lotID == lotID)[0];
             var foundIndex = found != undefined ? this.list.findLastIndex(x => x.lotID == found.lotID) : -1;
@@ -343,6 +344,7 @@ async function processSelectedDevices() {
         }
 
         doc.children[0].addEventListener('mouseup', (ev) => actions.manage(ev, lotID, selectedDevicesIDs));
+        doc.children[1].addEventListener('mouseup', (ev) => actions.manage(ev, lotID, selectedDevicesIDs));
         elementTarget.append(doc);
     }
 


### PR DESCRIPTION
This will fix an issue that makes the text in lots list con click and you can see that is clicked, but in javascript don't trigger select item

This is useful because it will change state of apply button

![image](https://user-images.githubusercontent.com/23123160/163961734-d3a7b814-fd96-4fc9-ba3d-6f471eb85eca.png)