### PR TITLE
fix the All devices option

### DIFF
--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -163,7 +163,7 @@ class FilterForm(FlaskForm):
 
         # Generic Filters
         if "All Devices" == self.device_type:
-            filter_type = None
+            filter_type = COMPUTERS + ["Monitor"] + MOBILE
 
         elif "All Components" == self.device_type:
             filter_type = COMPONENTS


### PR DESCRIPTION
Fix the "All Devices" option in the select Filter for search:
Computers + Monitors + Mobiles