### PR TITLE
Fix error when trade.document.url is None on device_list.html

### DIFF
--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -392,7 +392,7 @@
                     {% for doc in lot.trade.documents %}
                     <tr>
                       <td>
-                        {% if doc.url.to_text() %}
+                        {% if doc.url %}
                           <a href="{{ doc.url.to_text() }}" target="_blank">{{ doc.file_name}}</a>
                         {% else %}
                           {{ doc.file_name}}


### PR DESCRIPTION
Fixes [US 3380](https://tree.taiga.io/project/usody/us/3380)

```python
File "venv/lib/python3.9/site-packages/flask/app.py", line 2292, in wsgi_app
response = self.full_dispatch_request()
File "venv/lib/python3.9/site-packages/flask/app.py", line 1815, in full_dispatch_request
rv = self.handle_user_exception(e)
File "venv/lib/python3.9/site-packages/flask_cors/extension.py", line 165, in wrapped_function
return cors_after_request(app.make_response(f(*args, **kwargs)))
File "venv/lib/python3.9/site-packages/flask/app.py", line 1718, in handle_user_exception
reraise(exc_type, exc_value, tb)
File "venv/lib/python3.9/site-packages/flask/_compat.py", line 35, in reraise
raise value
File "venv/lib/python3.9/site-packages/flask/app.py", line 1813, in full_dispatch_request
rv = self.dispatch_request()
File "venv/lib/python3.9/site-packages/flask/app.py", line 1799, in dispatch_request
return self.view_functions[rule.endpoint](**req.view_args)
File "venv/lib/python3.9/site-packages/flask_login/utils.py", line 272, in decorated_view
return func(*args, **kwargs)
File "venv/lib/python3.9/site-packages/flask/views.py", line 88, in view
return self.dispatch_request(*args, **kwargs)
File "ereuse_devicehub/inventory/views.py", line 97, in dispatch_request
return flask.render_template(self.template_name, **self.context)
File "venv/lib/python3.9/site-packages/flask/templating.py", line 134, in render_template
return _render(ctx.app.jinja_env.get_or_select_template(template_name_or_list),
File "venv/lib/python3.9/site-packages/flask/templating.py", line 117, in _render
rv = template.render(context)
File "venv/lib/python3.9/site-packages/jinja2/environment.py", line 1291, in render
self.environment.handle_exception()
File "venv/lib/python3.9/site-packages/jinja2/environment.py", line 925, in handle_exception
raise rewrite_traceback_stack(source=source)
File "ereuse_devicehub/templates/inventory/device_list.html", line 1, in top-level template code
{% extends "ereuse_devicehub/base_site.html" %}
File "ereuse_devicehub/templates/ereuse_devicehub/base_site.html", line 1, in top-level template code
{% extends "ereuse_devicehub/base.html" %}
File "ereuse_devicehub/templates/ereuse_devicehub/base.html", line 44, in top-level template code
{% block body %}{% endblock %}
File "ereuse_devicehub/templates/ereuse_devicehub/base_site.html", line 213, in block 'body'
{% block main %}
File "ereuse_devicehub/templates/inventory/device_list.html", line 395, in block 'main'
{% if doc.url.to_text() %}
File "venv/lib/python3.9/site-packages/jinja2/utils.py", line 84, in from_obj
if hasattr(obj, "jinja_pass_arg"):
jinja2.exceptions.UndefinedError: 'None' has no attribute 'to_text'
```