### PR TITLE
Change/2973 sid in label

### DIFF
--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -402,6 +402,12 @@ class Device(Thing):
         return history
 
     @property
+    def sid(self):
+        actions = [x for x in self.actions if x.t == 'Snapshot' and x.sid]
+        if actions:
+            return actions[0]
+
+    @property
     def tradings(self):
         return {str(x.id): self.trading(x.lot) for x in self.actions if x.t == 'Trade'}
 

--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -405,7 +405,7 @@ class Device(Thing):
     def sid(self):
         actions = [x for x in self.actions if x.t == 'Snapshot' and x.sid]
         if actions:
-            return actions[0]
+            return actions[0].sid
 
     @property
     def tradings(self):

--- a/ereuse_devicehub/static/js/print.pdf.js
+++ b/ereuse_devicehub/static/js/print.pdf.js
@@ -24,6 +24,7 @@ function save_settings() {
     var sizePreset = $("#printerType").val();
     var data = {"height": height, "width": width, "sizePreset": sizePreset};
     data['dhid'] = $("#dhidCheck").prop('checked');
+    data['sid'] = $("#sidCheck").prop('checked');
     data['qr'] = $("#qrCheck").prop('checked');
     data['serial_number'] = $("#serialNumberCheck").prop('checked');
     data['manufacturer'] = $("#manufacturerCheck").prop('checked');
@@ -39,6 +40,7 @@ function load_settings() {
         $("#printerType").val(data.sizePreset);
         $("#qrCheck").prop('checked', data.qr);
         $("#dhidCheck").prop('checked', data.dhid);
+        $("#sidCheck").prop('checked', data.sid);
         $("#serialNumberCheck").prop('checked', data.serial_number);
         $("#manufacturerCheck").prop('checked', data.manufacturer);
         $("#modelCheck").prop('checked', data.model);
@@ -50,6 +52,7 @@ function reset_settings() {
     $("#printerType").val('brotherSmall');
     $("#qrCheck").prop('checked', true);
     $("#dhidCheck").prop('checked', true);
+    $("#sidCheck").prop('checked', true);
     $("#serialNumberCheck").prop('checked', false);
     $("#manufacturerCheck").prop('checked', false);
     $("#modelCheck").prop('checked', false);
@@ -73,6 +76,11 @@ function change_check() {
         $(".dhid").show();
     } else {
         $(".dhid").hide();
+    }
+    if ($("#sidCheck").prop('checked')) {
+        $(".sid").show();
+    } else {
+        $(".sid").hide();
     }
     if ($("#serialNumberCheck").prop('checked')) {
         $(".serial_number").show();
@@ -109,6 +117,9 @@ function printpdf() {
     min_tag_side = (Math.min(height, width)/2) + border;
     var last_tag_code = '';
 
+    if ($("#sidCheck").prop('checked')) {
+        height += line;
+    };
     if ($("#serialNumberCheck").prop('checked')) {
         height += line;
     };
@@ -144,6 +155,12 @@ function printpdf() {
                pdf.text(tag, border, space);
                space += line;
            }
+        };
+        if ($("#sidCheck").prop('checked')) {
+            var sn = $(y).data('sid');
+            pdf.setFontSize(15);
+            pdf.text(sn, border, space);
+            space += line;
         };
         if ($("#serialNumberCheck").prop('checked')) {
             var sn = $(y).data('serial-number');

--- a/ereuse_devicehub/templates/labels/print_labels.html
+++ b/ereuse_devicehub/templates/labels/print_labels.html
@@ -35,7 +35,8 @@
                           <div style="padding-top: 55px">
                               <b class="tag" data-serial-number="{{ dev.serial_number or '' }}"
                                   data-manufacturer="{{ dev.manufacturer or '' }}"
-                                  data-model="{{ dev.model or '' }}">{{ dev.devicehub_id }}</b>
+                                  data-model="{{ dev.model or '' }}"
+                                  data-sid="{{ dev.sid or '' }}">{{ dev.devicehub_id }}</b>
                           </div>
                         </div>
                       </div>
@@ -102,6 +103,10 @@
                     <div class="form-switch">
                       <input class="form-check-input" name="dhid" type="checkbox" id="dhidCheck" checked="">
                       <label class="form-check-label" for="dhidCheck">Dhid</label>
+                    </div>
+                    <div class="form-switch">
+                      <input class="form-check-input" name="sid" type="checkbox" id="dhidCheck">
+                      <label class="form-check-label" for="dhidCheck">Sid</label>
                     </div>
                     <div class="form-switch">
                       <input class="form-check-input" name="serial_number" type="checkbox" id="serialNumberCheck">

--- a/ereuse_devicehub/templates/labels/print_labels.html
+++ b/ereuse_devicehub/templates/labels/print_labels.html
@@ -39,6 +39,11 @@
                                   data-sid="{{ dev.sid or '' }}">{{ dev.devicehub_id }}</b>
                           </div>
                         </div>
+                        <div class="col sid" style="display: none">
+                          <div>
+                              <b>{{ dev.sid or '' }}</b>
+                          </div>
+                        </div>
                       </div>
                       <div class="row serial_number" style="display: none">
                         <div class="col">
@@ -105,8 +110,8 @@
                       <label class="form-check-label" for="dhidCheck">Dhid</label>
                     </div>
                     <div class="form-switch">
-                      <input class="form-check-input" name="sid" type="checkbox" id="dhidCheck">
-                      <label class="form-check-label" for="dhidCheck">Sid</label>
+                      <input class="form-check-input" name="sid" type="checkbox" id="sidCheck">
+                      <label class="form-check-label" for="sidCheck">Sid</label>
                     </div>
                     <div class="form-switch">
                       <input class="form-check-input" name="serial_number" type="checkbox" id="serialNumberCheck">


### PR DESCRIPTION
## Description
Possibility to add sid of a devices in the print label. By default it is activated.

## Type of change
Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## User story
[#2973](https://tree.taiga.io/project/usody/us/2973)