### PR TITLE
Update wb iso from 2022.5.2-beta to 2022.8.0-beta

### DIFF
--- a/ereuse_devicehub/workbench/__init__.py
+++ b/ereuse_devicehub/workbench/__init__.py
@@ -1,11 +1,14 @@
 isos = {
     "demo": {
-        'iso': "USODY_2022.5.2-beta.iso",
+        'iso': "USODY_2022.8.0-Demo.iso",
         'url': 'http://releases.usody.com/demo/',
     },
     "2022": {
-        'iso': "USODY_2022.5.2-beta.iso",
-        'url': 'http://releases.usody.com//2022/',
+        'iso': "USODY_2022.8.0-beta.iso",
+        'url': 'http://releases.usody.com/2022/',
     },
-    "v14": {'iso': "USODY_14.0.0.iso", 'url': 'http://releases.usody.com/v14/'},
+    "v14": {
+        'iso': "USODY_14.0.0.iso", 
+        'url': 'http://releases.usody.com/v14/'
+    },
 }


### PR DESCRIPTION
## Description
Update workbench ISOs version from 2022.5.2-beta to 2022.8.0-beta

Fixes # [3759](https://tree.taiga.io/project/usody/task/3759)