### PR TITLE
forze Phid to be string

### DIFF
--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -1520,7 +1520,9 @@ class UploadPlaceholderForm(FlaskForm):
         else:
             self.source = "Excel File: {}".format(_file.filename)
             try:
-                data = pd.read_excel(_file).fillna('').to_dict()
+                data = (
+                    pd.read_excel(_file, converters={'Phid': str}).fillna('').to_dict()
+                )
             except ValueError:
                 txt = ["File don't have a correct format"]
                 self.placeholder_file.errors = txt


### PR DESCRIPTION
## Description
When you up in upload placeholder a new file with numbers in phid columns, then pandas use this column as number

Fixes # ([3773](https://tree.taiga.io/project/usody/us/3773))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)