### PR TITLE
add Ods File as description in Placeholders Log

### DIFF
--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -1518,7 +1518,10 @@ class UploadPlaceholderForm(FlaskForm):
             data = data.fillna('').to_dict()
             return data
         else:
-            self.source = "Excel File: {}".format(_file.filename)
+            if _file.content_type == 'application/vnd.oasis.opendocument.spreadsheet':
+                self.source = "Ods File: {}".format(_file.filename)
+            else:
+                self.source = "Excel File: {}".format(_file.filename)
             try:
                 data = pd.read_excel(_file).fillna('').to_dict()
             except ValueError:


### PR DESCRIPTION
## Description
In placeholder logs page when we up a ods file, appear "Excel File" in the description, (source). We need change Excel File to ODS File in this page.

Fixes # ([3772](https://tree.taiga.io/project/usody/us/3772))