### PR TITLE
fix exports certificate for placeholders

### DIFF
--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -901,6 +901,8 @@ class ExportsView(View):
     def build_erasure_certificate(self):
         erasures = []
         for device in self.find_devices():
+            if device.placeholder and device.placeholder.binding:
+                device = device.placeholder.binding
             if isinstance(device, Computer):
                 for privacy in device.privacy:
                     erasures.append(privacy)

--- a/ereuse_devicehub/templates/inventory/erasure_list.html
+++ b/ereuse_devicehub/templates/inventory/erasure_list.html
@@ -63,7 +63,7 @@
                       <td>
                           <input type="checkbox" class="deviceSelect" data="{{ ac.device.id }}"
                                data-device-type="{{ ac.device.type }}" data-device-manufacturer="{{ ac.device.manufacturer }}"
-                               data-device-dhid="{{ ac.device.devicehub_id }}" data-device-vname="{{ ac.device.verbose_name }}"
+                               data-device-dhid="{{ ac.device.dhid }}" data-device-vname="{{ ac.device.verbose_name }}"
                                {% if form_new_allocate.type.data and ac.device.id in list_devices %}
                                  checked="checked"
                                {% endif %}


### PR DESCRIPTION
## Description
In testing is not possible get the correct certificate. The raison is that in testing for the migration process, all devices storage have a placeholder and this is the device than we get. For this raison we need check if the device select is a real parth or the abstract parth and then get the abstract parth for get the correct device with the certificate.