### PR TITLE
get the last update of one device

### DIFF
--- a/ereuse_devicehub/resources/device/models.py
+++ b/ereuse_devicehub/resources/device/models.py
@@ -629,6 +629,14 @@ class Device(Thing):
             return self.binding.device.devicehub_id
         return self.devicehub_id
 
+    @property
+    def get_updated(self):
+        if self.placeholder and self.placeholder.binding:
+            return max([self.updated, self.placeholder.binding.updated])
+        if self.binding:
+            return max([self.updated, self.binding.device.updated])
+        return self.updated
+
     @declared_attr
     def __mapper_args__(cls):
         """Defines inheritance.

--- a/ereuse_devicehub/templates/inventory/device_list.html
+++ b/ereuse_devicehub/templates/inventory/device_list.html
@@ -437,7 +437,7 @@
                       <td>{% if dev.status %}{{ dev.status.type }}{% endif %}</td>
                       <td>{% if dev.allocated_status %}{{ dev.allocated_status.type }}{% endif %}</td>
                       <td>{% if dev.physical_status %}{{ dev.physical_status.type }}{% endif %}</td>
-                      <td>{{ dev.updated.strftime('%Y-%m-%d %H:%M:%S')}}</td>
+                      <td>{{ dev.get_updated.strftime('%Y-%m-%d %H:%M:%S')}}</td>
                       <td>{{ dev.created.strftime('%Y-%m-%d %H:%M:%S')}}</td>
                       <td>
                         <a href="{{ dev.public_link }}" target="_blank">


### PR DESCRIPTION
## Description
I have updated a twin snapshot (19984, KX9PL), I have manually modified the snapshot changing its uuid and serial number, the result has been correct and the abstract device serial has changed
, but in the /inventory/all/device/ the “Updated in” date is still the placeholder creation date.

The “updated in” date should be updated if a snapshot of the twin is updated

Fixes # ([2656](https://tree.taiga.io/project/usody/us/2656))
Now we get the last update of the real parth or abstract parth

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)