### PR TITLE
fix dhid_bk

### DIFF
--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -299,8 +299,9 @@ class BindingView(GenericMixin):
 
         # to do a backup of abstract_dhid and abstract_phid in
         # workbench device
-        self.abstract_device.dhid_bk = self.abstract_dhid
-        self.abstract_device.phid_bk = self.abstract_phid
+        if self.abstract_device:
+            self.abstract_device.dhid_bk = self.abstract_dhid
+            self.abstract_device.phid_bk = self.abstract_phid
 
     def post(self):
         for plog in PlaceholdersLog.query.filter_by(

--- a/tests/test_render_2_0.py
+++ b/tests/test_render_2_0.py
@@ -2339,3 +2339,32 @@ def test_list_erasures(user3: UserClientFlask):
     txt = "WD-WCAV27984668"
     assert status == '200 OK'
     assert txt in body
+
+
+@pytest.mark.mvp
+@pytest.mark.usefixtures(conftest.app_context.__name__)
+def test_bug_3821_binding(user3: UserClientFlask):
+    uri = '/inventory/device/add/'
+    user3.get(uri)
+
+    data = {
+        'csrf_token': generate_csrf(),
+        'type': "Laptop",
+        'phid': 'sid',
+        'serial_number': "AAAAB",
+        'model': "LC27T55",
+        'manufacturer': "Samsung",
+        'generation': 1,
+        'weight': 0.1,
+        'height': 0.1,
+        'depth': 0.1,
+        'id_device_supplier': "b2",
+    }
+    user3.post(uri, data=data)
+    dev = Device.query.one()
+    dhid = dev.dhid
+    assert dev.phid() == 'sid'
+    uri = f'/inventory/binding/{dhid}/sid/'
+    body, status = user3.get(uri)
+    assert status == '200 OK'
+    assert 'is not a Snapshot device!' in body


### PR DESCRIPTION
## Description
When you select one placeholder from other placeholder not get the correct error message. The raison is that try save the dhid_bk over a None object.

Fixes # ([3821](https://tree.taiga.io/project/usody/us/3821))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Automatic test

- [x] test_bug_3821_binding