### PR TITLE
add placeholder device in lot instead of snapshot device

### DIFF
--- a/ereuse_devicehub/inventory/forms.py
+++ b/ereuse_devicehub/inventory/forms.py
@@ -299,7 +299,7 @@ class UploadSnapshotForm(SnapshotMixin, FlaskForm):
 
             response = self.build(snapshot_json)
             db.session.add(response)
-            devices.append(response.device)
+            devices.append(response.device.binding.device)
 
             if hasattr(response, 'type'):
                 self.result[filename] = 'Ok'


### PR DESCRIPTION
## Description
When we upload a snapshot from one lot, then add placeholder device in lot instead of snapshot device.

Fixes # ([3819](https://tree.taiga.io/project/usody/us/3819))

## Type of change
- [ x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Manual test
- [x] automatic test_upload_snapshot_to_lot