### PR TITLE
after do action from all device go to all device view

### DIFF
--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -654,7 +654,7 @@ class NewActionView(View):
         if lot_id:
             return url_for('inventory.lotdevicelist', lot_id=lot_id)
 
-        if url_for('inventory.alldevicelist') in request.referrer:
+        if url_for('inventory.alldevicelist') in (request.referrer or ''):
             return url_for('inventory.alldevicelist')
         return url_for('inventory.devicelist')
 

--- a/ereuse_devicehub/inventory/views.py
+++ b/ereuse_devicehub/inventory/views.py
@@ -654,6 +654,8 @@ class NewActionView(View):
         if lot_id:
             return url_for('inventory.lotdevicelist', lot_id=lot_id)
 
+        if url_for('inventory.alldevicelist') in request.referrer:
+            return url_for('inventory.alldevicelist')
         return url_for('inventory.devicelist')
 
 


### PR DESCRIPTION
## Description
if you are in the unassigned view and an action is applied, after the action the unassigned view should be displayed
If you are in the all devices view and apply an action, after the action the all devices view should be displayed

Fixes # ([3843](https://tree.taiga.io/project/usody/us/3843))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)