### PR TITLE
get the phid of the computer from where created

### DIFF
--- a/ereuse_devicehub/resources/action/models.py
+++ b/ereuse_devicehub/resources/action/models.py
@@ -476,9 +476,12 @@ class EraseBasic(JoinedWithOneDeviceMixin, ActionWithOneDevice):
         return urlutils.URL(url_for_resource('Document', item_id=self.id))
 
     def get_phid(self):
-        if self.device and self.device.parent:
-            if hasattr(self.device.parent, 'phid'):
-                return self.device.parent.phid()
+        """This method is used for get the phid of the computer when the action
+        was created. Usefull for get the phid of the computer were a hdd was
+        Ereased
+        """
+        if self.snapshot:
+            return self.snapshot.device.phid()
         return ''
 
     def __str__(self) -> str:


### PR DESCRIPTION
## Description
The view of "Data storage Erasures, not show correctly the column PHID Erasure host
Fixes # ([3848](https://tree.taiga.io/project/usody/us/3848))

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)