### PR TITLE
move links identifier and data storage to top

### DIFF
--- a/ereuse_devicehub/templates/ereuse_devicehub/base_site.html
+++ b/ereuse_devicehub/templates/ereuse_devicehub/base_site.html
@@ -39,6 +39,11 @@
           <i class="bi bi-search"></i>
         </a>
       </li><!-- End Search Icon-->
+      <li class="nav-item dropdown pe-3">
+        <a class="nav-link nav-profile d-flex align-items-center pe-0" href="{{ url_for('labels.label_list') }}">
+          <span class="d-none d-md-block ps-2 pb-3 pt-3">Identifiers</span>
+        </a>
+      </li>
 
       <li class="nav-item dropdown pe-3">
 
@@ -58,6 +63,11 @@
             <a class="dropdown-item d-flex align-items-center" href="{{ url_for('inventory.export', export_id='lots') }}">
               <i class="bi bi-file-spreadsheet"></i>
               <span>Lots Spreadsheet</span>
+            </a>
+          </li>
+          <li>
+            <a class="dropdown-item d-flex align-items-center" href="{{ url_for('inventory.device_erasure_list') }}">
+              <i class="bi bi-tag"></i><span>Data Storage Erasures</span>
             </a>
           </li>
         </ul>
@@ -251,22 +261,6 @@
             {% endfor %}
           </ul>
     </li><!-- End Temporal Lots Nav -->
-
-    <li class="nav-heading">Others views</li>
-
-    <li class="nav-item">
-      <a class="nav-link collapsed" href="{{ url_for('inventory.device_erasure_list') }}">
-        <i class="bi bi-tag"></i><span>Data Storage Erasures</span>
-      </a>
-    </li><!-- End Other views -->
-
-    <li class="nav-heading">Unique Identifiers (Tags)</li>
-
-    <li class="nav-item">
-      <a class="nav-link collapsed" href="{{ url_for('labels.label_list') }}">
-        <i class="bi bi-tag"></i><span>UI Management</span>
-      </a>
-    </li><!-- End Unique Identifiers -->
 
   </ul>
 


### PR DESCRIPTION
## Description
Mover links "UI Mangement" and "Data Storage Erasures" to the top right menu.

Fixes # ([3883](https://tree.taiga.io/project/usody/us/3883))

## Type of change

- [x] This change requires a documentation update