### PR TITLE
add tests and redirect from abstract device to twin page

### DIFF
--- a/ereuse_devicehub/resources/device/views.py
+++ b/ereuse_devicehub/resources/device/views.py
@@ -137,7 +137,10 @@ class DeviceView(View):
             return self.one_private(id)
 
     def one_public(self, id: int):
-        device = Device.query.filter_by(devicehub_id=id, active=True).one()
+        devices = Device.query.filter_by(devicehub_id=id, active=True).all()
+        if not devices:
+            devices = [Device.query.filter_by(dhid_bk=id, active=True).one()]
+        device = devices[0]
         abstract = None
         if device.binding:
             return flask.redirect(device.public_link)

--- a/tests/test_render_2_0.py
+++ b/tests/test_render_2_0.py
@@ -1675,6 +1675,7 @@ def test_export_lots(user3: UserClientFlask):
 @pytest.mark.mvp
 @pytest.mark.usefixtures(conftest.app_context.__name__)
 def test_export_snapshot_json(user3: UserClientFlask):
+    # ??
     file_name = 'real-eee-1001pxd.snapshot.13.json'
     snap = create_device(user3, file_name)
 
@@ -2158,8 +2159,15 @@ def test_manual_binding(user3: UserClientFlask):
     # check new structure
     assert dev_wb.binding.phid == '1'
     assert dev_wb.binding.device == dev
+    assert dev_wb.phid() == dev.phid()
+    assert dev_wb.is_abstract() == dev.is_abstract() == 'Twin'
+    # assert dev_wb.
     assert Placeholder.query.filter_by(id=old_placeholder.id).first() is None
     assert Device.query.filter_by(id=old_placeholder.device.id).first() is None
+
+    body_real, status = user3.get(f'/devices/{dhid_real}')
+    body_abstract, status = user3.get(f'/devices/{dhid_abstract}')
+    assert body_real == body_abstract
 
 
 @pytest.mark.mvp


### PR DESCRIPTION
## Description
do a redirect to twin page when the url is from the snapshot device.

Fixes # ([3830](https://tree.taiga.io/project/usody/us/3830))

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Manual test
- [x] automatic test