### PR TITLE
put api_host in config

### DIFF
--- a/ereuse_devicehub/config.py
+++ b/ereuse_devicehub/config.py
@@ -59,6 +59,7 @@ class DevicehubConfig(Config):
     )  # type: str
     SCHEMA = config('SCHEMA', 'dbtest')
     HOST = config('HOST', 'localhost')
+    API_HOST = config('API_HOST', 'localhost')
     MIN_WORKBENCH = StrictVersion('11.0a1')  # type: StrictVersion
     """The minimum version of ereuse.org workbench that this devicehub
     accepts. we recommend not changing this value.

--- a/ereuse_devicehub/workbench/views.py
+++ b/ereuse_devicehub/workbench/views.py
@@ -55,7 +55,7 @@ class SettingsView(GenericMixin):
         return flask.render_template(self.template_name, **self.context)
 
     def download(self):
-        url = "https://{}/api/inventory/".format(app.config['HOST'])
+        url = "https://{}/api/inventory/".format(app.config['API_HOST'])
         self.wbContext = {
             'token': self.get_token(),
             'url': url,
@@ -65,7 +65,7 @@ class SettingsView(GenericMixin):
         # if is a v14 version
         # TODO when not use more v14, we can remove this if
         if 'erease' in self.opt:
-            url = "https://{}/actions/".format(app.config['HOST'])
+            url = "https://{}/actions/".format(app.config['API_HOST'])
             self.wbContext['url'] = url
             self.wbContext['host'] = app.config['HOST']
             self.wbContext['schema'] = app.config['SCHEMA']


### PR DESCRIPTION
## Description
We need split in 2 environment vars the concept of HOST. One is for show to the users urls where they can go. Other is the host for the connection of api for the workbench.

Fixes # ([4042](https://tree.taiga.io/project/usody/us/4042))

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)