### PR TITLE
Bugfix/4464 export hdd

### DIFF
--- a/ereuse_devicehub/resources/device/sync.py
+++ b/ereuse_devicehub/resources/device/sync.py
@@ -92,9 +92,20 @@ class Sync:
             # We only want to perform Add/Remove to not new components
             actions = self.add_remove(db_device, not_new_components)
             db_device.components = db_components
+            self.clean_parent_orphans_components(db_device)
 
         self.create_placeholder(db_device)
         return db_device, actions
+
+    def clean_parent_orphans_components(self, device):
+        all_components = Component.query.filter_by(parent_id=device.id)
+        for _c in all_components:
+            if _c not in device.components:
+                _c.parent = None
+                if _c.binding:
+                    _c.binding.device.parent = None
+                if _c.placeholder and _c.placeholder.binding:
+                    _c.placeholder.binding.parent = None
 
     def execute_register_component(self, component: Component):
         """Synchronizes one component to the DB.

--- a/ereuse_devicehub/resources/documents/device_row.py
+++ b/ereuse_devicehub/resources/documents/device_row.py
@@ -422,30 +422,37 @@ class DeviceRow(BaseDeviceRow):
         self['{} {} Speed (MHz)'.format(ctype, i)] = none2str(component.speed)
 
     def get_erasure_datawipe_mobile(self, device):
+        if isinstance(device, d.DataStorage):
+            if device.placeholder and device.placeholder.binding:
+                binding = device.placeholder.binding
+                return self.get_datastorage('DataStorage', 1, binding)
+            return self.get_datastorage('DataStorage', 1, device)
+
+        if not isinstance(device, d.Mobile):
+            return
+
         actions = sorted(device.actions)
         erasures = [a for a in actions if a.type == 'EraseDataWipe']
         erasure = erasures[-1] if erasures else None
-        if erasure:
-            self['Erasure DataStorage 1'] = none2str(device.chid)
-            if isinstance(device, d.Mobile):
-                serial_number = none2str(device.imei)
-                size = device.data_storage_size
-                size = size * 1000 if size else 0
-                storage_size = none2str(size)
 
-            if isinstance(device, d.DataStorage):
-                serial_number = none2str(device.serial_number)
-                storage_size = none2str(device.size)
+        if not erasure:
+            return
 
-            self['Erasure DataStorage 1 Serial Number'] = serial_number
-            self['Erasure DataStorage 1 Size (MB)'] = storage_size
-            self['Erasure DataStorage 1 Software'] = erasure.document.software
-            self['Erasure DataStorage 1 Result'] = get_result(erasure)
-            self['Erasure DataStorage 1 Type'] = erasure.type
-            self['Erasure DataStorage 1 Date'] = format(erasure.document.date or '')
-            self['Erasure DataStorage 1 Certificate URL'] = (
-                erasure.document.url and erasure.document.url.to_text() or ''
-            )
+        self['Erasure DataStorage 1'] = none2str(device.chid)
+        serial_number = none2str(device.imei)
+        size = device.data_storage_size
+        size = size * 1000 if size else 0
+        storage_size = none2str(size)
+
+        self['Erasure DataStorage 1 Serial Number'] = serial_number
+        self['Erasure DataStorage 1 Size (MB)'] = storage_size
+        self['Erasure DataStorage 1 Result'] = get_result(erasure)
+        self['Erasure DataStorage 1 Type'] = erasure.type
+        self['Erasure DataStorage 1 Software'] = erasure.document.software
+        self['Erasure DataStorage 1 Date'] = format(erasure.document.date or '')
+        self['Erasure DataStorage 1 Certificate URL'] = (
+            erasure.document.url and erasure.document.url.to_text() or ''
+        )
 
     def get_datastorage(self, ctype, i, component):
         """Particular fields for component DataStorage.


### PR DESCRIPTION
## Description
* When download one DataStorage with erasure action from workbench and this disk is orphan, then the export devices not have the details of erasure action.
* Have an other bug when remove one disk from one computer and this disk is now orphan, not remove correctly the parent relation in the table of database.

Fixes # ([4464](https://tree.taiga.io/project/usody/us/4464))

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)